### PR TITLE
Feature/indicator edit page

### DIFF
--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -37,6 +37,8 @@ class IndicatorsController < ApplicationController
   end
 
   def indicator_params
-    params.require(:indicator).permit(*Indicator.attribute_symbols_for_strong_params)
+    params.require(:indicator).permit(
+      *Indicator.attribute_symbols_for_strong_params
+    )
   end
 end

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -1,5 +1,42 @@
 class IndicatorsController < ApplicationController
+  before_action :set_indicator, except: [:index, :new, :create]
   def index
     @indicators = Indicator.order(:category, :stack_family, :name)
+  end
+
+  def new
+    @indicator = Indicator.new
+    render action: :edit
+  end
+
+  def create
+    @indicator = Indicator.new(indicator_params)
+    if @indicator.save
+      redirect_to indicator_url(@indicator)
+    else
+      render action: :edit
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @indicator.update_attributes(indicator_params)
+      redirect_to indicator_url(@indicator)
+    else
+      render action: :edit
+    end
+  end
+
+  def show; end
+
+  private
+
+  def set_indicator
+    @indicator = Indicator.find(params[:id])
+  end
+
+  def indicator_params
+    params.require(:indicator).permit(*Indicator.attribute_symbols_for_strong_params)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,29 @@
 module ApplicationHelper
+  def attribute_name(object, attribute_symbol)
+    t object.key_for_name(attribute_symbol)
+  end
+
+  def attribute_definition(object, attribute_symbol)
+    t object.key_for_definition(attribute_symbol)
+  end
+
+  def attribute_input(object, form, attribute_symbol)
+    if object.class.picklist_attribute?(attribute_symbol)
+      picklist_input(object, form, attribute_symbol)
+    else
+      form.text_field attribute_symbol
+    end
+  end
+
+  def picklist_input(object, form, attribute_symbol)
+    is_multiple = object.class.multiple_attribute?(attribute_symbol)
+    picklist_values = object.class.
+      distinct.order(attribute_symbol).pluck(attribute_symbol)
+    picklist_values = picklist_values.flatten.uniq if is_multiple
+    picklist_values = picklist_values.compact
+    options = {prompt: 'Please select'}
+    html_options = {}
+    html_options[:multiple] = true if is_multiple
+    form.select attribute_symbol, picklist_values, options, html_options
+  end
 end

--- a/app/helpers/models_helper.rb
+++ b/app/helpers/models_helper.rb
@@ -1,29 +1,2 @@
 module ModelsHelper
-  def attribute_name(attribute_symbol)
-    t @model.key_for_name(attribute_symbol)
-  end
-
-  def attribute_definition(attribute_symbol)
-    t @model.key_for_definition(attribute_symbol)
-  end
-
-  def attribute_input(form, attribute_symbol)
-    if Model.picklist_attribute?(attribute_symbol)
-      picklist_input(form, attribute_symbol)
-    else
-      form.text_field attribute_symbol
-    end
-  end
-
-  def picklist_input(form, attribute_symbol)
-    is_multiple = Model.multiple_attribute?(attribute_symbol)
-    picklist_values = Model.
-      distinct.order(attribute_symbol).pluck(attribute_symbol)
-    picklist_values = picklist_values.flatten.uniq if is_multiple
-    picklist_values = picklist_values.compact
-    options = {prompt: 'Please select'}
-    html_options = {}
-    html_options[:multiple] = true if is_multiple
-    form.select attribute_symbol, picklist_values, options, html_options
-  end
 end

--- a/app/views/indicators/edit.html.erb
+++ b/app/views/indicators/edit.html.erb
@@ -1,0 +1,13 @@
+<%= form_for @indicator do |f| %>
+  <%= link_to 'CANCEL', indicators_url %>
+  <%= f.submit 'SAVE' %>
+  <ul>
+    <% Indicator.attribute_symbols.each do |attribute_symbol| %>
+    <li>
+      <%= attribute_name(@indicator, attribute_symbol) %>
+      (<%= attribute_definition(@indicator, attribute_symbol) %>)
+      <%= attribute_input(@indicator, f, attribute_symbol) %>
+    </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/indicators/index.html.erb
+++ b/app/views/indicators/index.html.erb
@@ -23,7 +23,7 @@
   <tbody>
   <% @indicators.each do |indicator| %>
     <tr>
-      <th><%= indicator.name %></th>
+      <th><%= link_to indicator.name, indicator_url(indicator) %></th>
       <th><%= indicator.category %></th>
       <th><%= indicator.stack_family %></th>
       <th><%= indicator.unit %></th>

--- a/app/views/indicators/show.html.erb
+++ b/app/views/indicators/show.html.erb
@@ -1,0 +1,21 @@
+<h1>Indicator <%= @indicator.name %></h1>
+
+Category: <%= @indicator.category %>
+Unit: <%= @indicator.unit %>
+Added by: TODO
+Description: <%= @indicator.definition %>
+<%= link_to 'EDIT', edit_indicator_url(@indicator) %>
+
+<p>Models using this indicator: <i>TODO: all models for now</i></p>
+<ul>
+<% Model.all.each do |model| %>
+  <li><%= model.full_name %> <%=link_to 'EDIT', edit_model_url(model) %></li>
+<% end %>
+</ul>
+
+<p>Scenarios using this indicator: <i>TODO: all scenarios for now</i></p>
+<ul>
+<% Scenario.all.each do |scenario| %>
+  <li><%= scenario.name %> <%=link_to 'EDIT TODO link', '#' %></li>
+<% end %>
+</ul>

--- a/app/views/models/edit.html.erb
+++ b/app/views/models/edit.html.erb
@@ -6,9 +6,9 @@
   <ul>
     <% Model.attribute_symbols.each do |attribute_symbol| %>
     <li>
-      <%= attribute_name(attribute_symbol) %>
-      (<%= attribute_definition(attribute_symbol) %>)
-      <%= attribute_input(f, attribute_symbol) %>
+      <%= attribute_name(@model, attribute_symbol) %>
+      (<%= attribute_definition(@model, attribute_symbol) %>)
+      <%= attribute_input(@model, f, attribute_symbol) %>
     </li>
     <% end %>
   </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,3 +177,22 @@ en:
     point_of_contact:
       name: "Point-of-Contact"
       definition:  "Who is the point-of-contact for the model?"
+  indicators:
+    category:
+      name: 'Category'
+      definition: 'TODO'
+    stack_family:
+      name: 'Stack family'
+      definition: 'TODO'
+    name:
+      name: 'Name'
+      definition: 'TODO'
+    definition:
+      name: 'Description'
+      definition: 'TODO'
+    unit:
+      name: 'Unit'
+      definition: 'TODO'
+    notes:
+      name: 'Notes'
+      definition: 'TODO'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resources :models, only: [:index, :show, :edit, :update] do
     resources :scenarios, only: [:index], shallow: true
   end
-  resources :indicators, only: [:index, :new, :edit, :destroy]
+  resources :indicators, only: [:index, :show, :new, :create, :edit, :update, :destroy]
 
   root to: 'models#index'
 end

--- a/lib/modules/metadata_attributes.rb
+++ b/lib/modules/metadata_attributes.rb
@@ -38,10 +38,12 @@ module MetadataAttributes
   end
 
   def key_for_name(attribute_symbol)
-    ['models', attribute_symbol, 'name'].join('.')
+    [self.class.name.downcase.pluralize, attribute_symbol, 'name'].join('.')
   end
 
   def key_for_definition(attribute_symbol)
-    ['models', attribute_symbol, 'definition'].join('.')
+    [
+      self.class.name.downcase.pluralize, attribute_symbol, 'definition'
+    ].join('.')
   end
 end

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -9,4 +9,49 @@ RSpec.describe IndicatorsController, type: :controller do
       expect(response).to render_template(:index)
     end
   end
+
+  describe 'GET new' do
+    it 'renders edit' do
+      get :new
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'POST create' do
+    it 'renders edit when validation errors present' do
+      post :create, params: {indicator: {name: nil}}
+      expect(response).to render_template(:edit)
+    end
+
+    it 'redirects to indicator when successful' do
+      post :create, params: {indicator: {name: 'ABC'}}
+      expect(response).to redirect_to(indicator_url(assigns(:indicator)))
+    end
+  end
+
+  describe 'GET edit' do
+    it 'renders edit' do
+      get :edit, params: {id: indicator.id}
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'PUT update' do
+    it 'renders edit when validation errors present' do
+      put :update, params: {id: indicator.id, indicator: {name: nil}}
+      expect(response).to render_template(:edit)
+    end
+
+    it 'redirects to indicator when successful' do
+      put :update, params: {id: indicator.id, indicator: {name: 'ABC'}}
+      expect(response).to redirect_to(indicator_url(indicator))
+    end
+  end
+
+  describe 'GET show' do
+    it 'renders show' do
+      get :show, params: {id: indicator.id}
+      expect(response).to render_template(:show)
+    end
+  end
 end


### PR DESCRIPTION
Adds a new / edit indicator page and a show page.
Note: for the indicator form the same helpers are used as previously for the model form; in order to make them reusable they now take an extra parameter & have been moved to application helper.