### PR TITLE
Use long routes instead of shallow routes for scenarios

### DIFF
--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -1,30 +1,25 @@
 class ScenariosController < ApplicationController
-  before_action :set_model, only: [:index]
+  before_action :set_model
   before_action :set_scenario, except: [:index]
 
   def index
     @scenarios = @model.scenarios
   end
 
-  def edit
-    @model = @scenario.model
-  end
+  def edit; end
 
   def update
     if @scenario.update_attributes(scenario_params)
-      redirect_to scenario_url(@scenario)
+      redirect_to model_scenario_url(@model, @scenario)
     else
       render action: :edit
     end
   end
 
-  def show
-    @scenario = Scenario.find(params[:id])
-  end
+  def show; end
 
   def destroy
     @scenario = Scenario.find(params[:id])
-    @model = @scenario.model
     @scenario.destroy
     redirect_to(
       model_scenarios_url(@model),

--- a/app/views/scenarios/edit.html.erb
+++ b/app/views/scenarios/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @scenario do |f| %>
+<%= form_for [@model, @scenario] do |f| %>
   <%= link_to 'CANCEL', model_scenarios_url(@model) %>
   <%= f.submit 'SAVE' %>
   <ul>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -30,14 +30,14 @@ Scenarios (<%= @scenarios.count %>)
   <tbody>
   <% @scenarios.each do |scenario| %>
     <tr>
-      <td><%= link_to scenario.name, scenario_url(scenario) %></td>
+      <td><%= link_to scenario.name, model_scenario_url(@model, scenario) %></td>
       <td><%= scenario.updated_at.strftime("%b %d %Y") %></td>
       <td><%= scenario.meta_data? %></td>
       <td><%= scenario.time_series_data? %></td>
       <td><%= scenario.indicators.count %></td>
       <td>
-        <%= link_to 'DELETE', scenario_url(scenario), method: :delete, data: {confirm: destroy_confirmation_message(scenario)} %>
-        <%= link_to 'EDIT', edit_scenario_url(scenario) %>
+        <%= link_to 'DELETE', model_scenario_url(@model, scenario), method: :delete, data: {confirm: destroy_confirmation_message(scenario)} %>
+        <%= link_to 'EDIT', edit_model_scenario_url(@model, scenario) %>
       </td>
     </tr>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   resources :models, only: [:index, :show, :edit, :update] do
     post :upload_meta_data, on: :collection
-    resources :scenarios, only: [:index, :show, :edit, :update, :destroy], shallow: true do
+    resources :scenarios, only: [:index, :show, :edit, :update, :destroy] do
       post :upload_meta_data, on: :collection
       post :upload_time_series, on: :collection, to: 'time_series_values#upload', as: :upload_time_series
     end

--- a/spec/controllers/scenarios_controller_spec.rb
+++ b/spec/controllers/scenarios_controller_spec.rb
@@ -13,34 +13,38 @@ RSpec.describe ScenariosController, type: :controller do
 
   describe 'GET show' do
     it 'renders show' do
-      get :show, params: {id: scenario.id}
+      get :show, params: {model_id: model.id, id: scenario.id}
       expect(response).to render_template(:show)
     end
   end
 
   describe 'GET edit' do
     it 'renders edit' do
-      get :edit, params: {id: scenario.id}
+      get :edit, params: {model_id: model.id, id: scenario.id}
       expect(response).to render_template(:edit)
     end
   end
 
   describe 'PUT update' do
     it 'renders edit when validation errors present' do
-      put :update, params: {id: scenario.id, scenario: {name: nil}}
+      put :update, params: {
+        model_id: model.id, id: scenario.id, scenario: {name: nil}
+      }
       expect(response).to render_template(:edit)
     end
 
     it 'redirects to indicator when successful' do
-      put :update, params: {id: scenario.id, scenario: {name: 'ABC'}}
-      expect(response).to redirect_to(scenario_url(scenario))
+      put :update, params: {
+        model_id: model.id, id: scenario.id, scenario: {name: 'ABC'}
+      }
+      expect(response).to redirect_to(model_scenario_url(model, scenario))
     end
   end
 
   describe 'DELETE destroy' do
     it 'redirects to index' do
-      delete :destroy, params: {id: scenario.id}
-      expect(response).to redirect_to(model_scenarios_url(scenario.model))
+      delete :destroy, params: {model_id: model.id, id: scenario.id}
+      expect(response).to redirect_to(model_scenarios_url(model))
     end
   end
 end


### PR DESCRIPTION
Puts in place long scenario urls with `/model/id/` prefix; will change the id to slug separately as that's a bit more work, the url helpers should remain the same.