### PR TITLE
Allow single selection attributes as arrays with conversion

### DIFF
--- a/spec/controllers/models_controller_spec.rb
+++ b/spec/controllers/models_controller_spec.rb
@@ -35,5 +35,19 @@ RSpec.describe ModelsController, type: :controller do
       put :update, params: {id: model.id, model: {abbreviation: 'ABC'}}
       expect(response).to redirect_to(model_url(model))
     end
+
+    it 'filters parameters correctly for update' do
+      model_params = {
+        abbreviation: 'ABC',
+        programming_language: ['', 'ruby', 'perl'],
+        time_horizon: ['', 'century']
+      }
+      expect_any_instance_of(Model).to receive(:update_attributes).
+        with(ActionController::Parameters.new(model_params).permit!)
+      put :update, params: {
+        id: model.id,
+        model: model_params
+      }
+    end
   end
 end

--- a/spec/controllers/scenarios_controller_spec.rb
+++ b/spec/controllers/scenarios_controller_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe ScenariosController, type: :controller do
       }
       expect(response).to redirect_to(model_scenario_url(model, scenario))
     end
+
+    it 'filters parameters correctly for update' do
+      scenario_params = {
+        name: 'ABC',
+        technology_coverage: ['', 'A', 'B'],
+        category: ['', 'cat1']
+      }
+      expect_any_instance_of(Scenario).to receive(:update_attributes).
+        with(ActionController::Parameters.new(scenario_params).permit!)
+      put :update, params: {
+        model_id: model.id,
+        id: scenario.id,
+        scenario: scenario_params
+      }
+    end
   end
 
   describe 'DELETE destroy' do

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -19,10 +19,15 @@ RSpec.describe Model, type: :model do
   end
 
   describe :create do
-    it 'ignores blank array values' do
+    it 'ignores blank array values for multiple selection attributes' do
       attributes = FactoryGirl.attributes_for(:model).
         merge(programming_language: ['', 'Python', 'ruby', 'perl'])
       expect(Model.create(attributes).programming_language.length).to eq(3)
+    end
+    it 'ignores blank array values for single selection attributes' do
+      attributes = FactoryGirl.attributes_for(:model).
+        merge(time_horizon: ['', 'century'])
+      expect(Model.create(attributes).time_horizon).to eq('century')
     end
   end
 


### PR DESCRIPTION
In order to work around a select2 quirk, we allow single selection values to be passed as arrays, e.g.
`"maintainer_type"=>["", "private"]`
and then parse that before saving the value.