### PR TITLE
Feature/authorisation checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - 'config/environments/*'
     - 'config/initializers/*'
     - 'config/*'
+    - 'app/models/ability.rb'
 
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'jbuilder', '~> 2.5'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
+gem 'cancancan', '~> 1.10'
 gem 'devise'
 gem 'devise_invitable'
 gem 'sendgrid-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     bindex (0.5.0)
     builder (3.2.3)
     byebug (9.0.6)
+    cancancan (1.17.0)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -258,6 +259,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  cancancan (~> 1.10)
   coffee-rails (~> 4.2)
   devise
   devise_invitable

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,13 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
 
+  rescue_from CanCan::AccessDenied do |exception|
+    respond_to do |format|
+      format.json { head :forbidden }
+      format.html { redirect_to root_url, alert: exception.message }
+    end
+  end
+
   private
 
   def set_nav_links

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -1,5 +1,10 @@
 class IndicatorsController < ApplicationController
-  before_action :set_indicator, except: [:index, :new, :create]
+  # TODO: once per-model indicators in place
+  # load_and_authorize_resource :model
+  # load_and_authorize_resource through: :model, except: [:index]
+  load_and_authorize_resource except: [:index]
+  authorize_resource only: [:index]
+
   before_action :set_filter_params, only: [:index]
 
   def index
@@ -36,7 +41,6 @@ class IndicatorsController < ApplicationController
   def show; end
 
   def destroy
-    @indicator = Indicator.find(params[:id])
     @indicator.destroy
     redirect_to indicators_url, notice: 'Indicator successfully destroyed'
   end
@@ -46,10 +50,6 @@ class IndicatorsController < ApplicationController
   end
 
   private
-
-  def set_indicator
-    @indicator = Indicator.find(params[:id])
-  end
 
   def indicator_params
     params.require(:indicator).permit(

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -1,10 +1,9 @@
 class ModelsController < ApplicationController
-  before_action :set_team
-  before_action :set_model, except: [:index]
+  load_and_authorize_resource
+
   before_action :set_nav_links, only: [:index, :show, :edit]
 
   def index
-    @models = @team.models
     redirect_to model_url(@models.first) and return if @models.length == 1
   end
 
@@ -28,14 +27,6 @@ class ModelsController < ApplicationController
   end
 
   private
-
-  def set_team
-    @team = Team.first # TODO
-  end
-
-  def set_model
-    @model = Model.find(params[:id])
-  end
 
   def model_params
     params.require(:model).permit(*Model.attribute_symbols_for_strong_params)

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -1,6 +1,8 @@
 class ScenariosController < ApplicationController
-  before_action :set_model
-  before_action :set_scenario, except: [:index]
+  load_and_authorize_resource :model
+  load_and_authorize_resource through: :model, except: [:index]
+  authorize_resource only: [:index]
+
   before_action :set_nav_links, only: [:index, :show, :edit]
   before_action :set_filter_params, only: [:index, :show]
 
@@ -26,7 +28,6 @@ class ScenariosController < ApplicationController
   end
 
   def destroy
-    @scenario = Scenario.find(params[:id])
     @scenario.destroy
     redirect_to(
       model_scenarios_url(@model),
@@ -39,14 +40,6 @@ class ScenariosController < ApplicationController
   end
 
   private
-
-  def set_model
-    @model = Model.find(params[:model_id])
-  end
-
-  def set_scenario
-    @scenario = Scenario.find(params[:id])
-  end
 
   def scenario_params
     params.require(:scenario).permit(

--- a/app/controllers/team_users_controller.rb
+++ b/app/controllers/team_users_controller.rb
@@ -1,5 +1,8 @@
 class TeamUsersController < ApplicationController
   before_action :set_team
+  load_and_authorize_resource :team
+  load_and_authorize_resource :user, parent: false, only: [:destroy]
+  authorize_resource :user, parent: false, only: [:create]
 
   def create
     email = user_params[:email].downcase.strip
@@ -19,7 +22,6 @@ class TeamUsersController < ApplicationController
   end
 
   def destroy
-    @user = User.find(params[:id])
     @user.team_id = nil
     @user.save(validate: false)
     redirect_to(

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,5 +1,6 @@
 class TeamsController < ApplicationController
-  before_action :set_team, only: [:edit, :update, :destroy]
+  load_and_authorize_resource
+
   before_action :set_filter_params, only: [:index]
 
   def index
@@ -28,7 +29,7 @@ class TeamsController < ApplicationController
   end
 
   def update
-    if @team.update(team_params)
+    if @team.update_attributes(team_params)
       redirect_to edit_team_url(@team), notice: 'Team was successfully updated.'
     else
       set_available_models
@@ -42,10 +43,6 @@ class TeamsController < ApplicationController
   end
 
   private
-
-  def set_team
-    @team = Team.find(params[:id])
-  end
 
   def set_available_models
     @models =

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,6 +9,7 @@ class Ability
       can :manage, :all
     else
       can :manage, Model, team_id: team.id
+      can :manage, Scenario, model: {team_id: team.id}
     end
     #
     # The first argument to `can` is the action you are giving the user

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,32 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    user ||= User.new # guest user (not logged in)
+    team = user.team
+    if user.admin?
+      can :manage, :all
+    else
+      can :manage, Model, team_id: team.id
+    end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,6 +12,8 @@ class Ability
       can :manage, Scenario, model: {team_id: team.id}
       # TODO: finalize when per-model indicators in place
       can :manage, Indicator
+      can :edit, Team, id: team.id
+      can :update, Team, id: team.id
     end
     #
     # The first argument to `can` is the action you are giving the user

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,6 +10,8 @@ class Ability
     else
       can :manage, Model, team_id: team.id
       can :manage, Scenario, model: {team_id: team.id}
+      # TODO: finalize when per-model indicators in place
+      can :manage, Indicator
     end
     #
     # The first argument to `can` is the action you are giving the user

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,8 +12,13 @@ class Ability
       can :manage, Scenario, model: {team_id: team.id}
       # TODO: finalize when per-model indicators in place
       can :manage, Indicator
+      can :show, Team, id: team.id
       can :edit, Team, id: team.id
       can :update, Team, id: team.id
+      can :create, User do |user|
+        user.team.nil? || user.team_id == team.id
+      end
+      can :destroy, User, team_id: team.id
     end
     #
     # The first argument to `can` is the action you are giving the user

--- a/app/models/time_series_value.rb
+++ b/app/models/time_series_value.rb
@@ -10,4 +10,7 @@ class TimeSeriesValue < ApplicationRecord
     inclusion: {in: 1900..2100, allow_nil: true}
   )
   validates :value, presence: true, numericality: {allow_nil: true}
+  validates :scenario, presence: true
+  validates :indicator, presence: true
+  validates :location, presence: true
 end

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -1,65 +1,99 @@
 require 'rails_helper'
 
 RSpec.describe IndicatorsController, type: :controller do
-  login_user
-  let!(:indicator) { FactoryGirl.create(:indicator) }
-
-  describe 'GET index' do
-    it 'renders index' do
-      get :index
-      expect(response).to render_template(:index)
-    end
+  context 'when admin' do
+    login_admin
+    let(:team_model) { FactoryGirl.create(:model, team: @user.team) }
+    let(:some_model) { FactoryGirl.create(:model) }
+    let(:team_indicator) {
+      i = FactoryGirl.create(:indicator)
+      s = FactoryGirl.create(:scenario, model: team_model)
+      FactoryGirl.create(:time_series_value, indicator: i, scenario: s)
+      i
+    }
+    let(:some_indicator) {
+      i = FactoryGirl.create(:indicator)
+      s = FactoryGirl.create(:scenario, model: some_model)
+      FactoryGirl.create(:time_series_value, indicator: i, scenario: s)
+      i
+    }
+    pending 'add more specs when per-model indicators in place'
   end
 
-  describe 'GET new' do
-    it 'renders edit' do
-      get :new
-      expect(response).to render_template(:edit)
-    end
-  end
+  context 'when user' do
+    login_user
+    let(:team_model) { FactoryGirl.create(:model, team: @user.team) }
+    let(:some_model) { FactoryGirl.create(:model) }
+    let(:team_indicator) {
+      i = FactoryGirl.create(:indicator)
+      s = FactoryGirl.create(:scenario, model: team_model)
+      FactoryGirl.create(:time_series_value, indicator: i, scenario: s)
+      i
+    }
+    let(:some_indicator) {
+      i = FactoryGirl.create(:indicator)
+      s = FactoryGirl.create(:scenario, model: some_model)
+      FactoryGirl.create(:time_series_value, indicator: i, scenario: s)
+      i
+    }
 
-  describe 'POST create' do
-    it 'renders edit when validation errors present' do
-      post :create, params: {indicator: {name: nil}}
-      expect(response).to render_template(:edit)
-    end
-
-    it 'redirects to indicator when successful' do
-      post :create, params: {indicator: {name: 'ABC'}}
-      expect(response).to redirect_to(indicator_url(assigns(:indicator)))
-    end
-  end
-
-  describe 'GET edit' do
-    it 'renders edit' do
-      get :edit, params: {id: indicator.id}
-      expect(response).to render_template(:edit)
-    end
-  end
-
-  describe 'PUT update' do
-    it 'renders edit when validation errors present' do
-      put :update, params: {id: indicator.id, indicator: {name: nil}}
-      expect(response).to render_template(:edit)
+    describe 'GET index' do
+      it 'renders index' do
+        get :index
+        expect(response).to render_template(:index)
+      end
     end
 
-    it 'redirects to indicator when successful' do
-      put :update, params: {id: indicator.id, indicator: {name: 'ABC'}}
-      expect(response).to redirect_to(indicator_url(indicator))
+    describe 'GET new' do
+      it 'renders edit' do
+        get :new
+        expect(response).to render_template(:edit)
+      end
     end
-  end
 
-  describe 'GET show' do
-    it 'renders show' do
-      get :show, params: {id: indicator.id}
-      expect(response).to render_template(:show)
+    describe 'POST create' do
+      it 'renders edit when validation errors present' do
+        post :create, params: {indicator: {name: nil}}
+        expect(response).to render_template(:edit)
+      end
+
+      it 'redirects to indicator when successful' do
+        post :create, params: {indicator: {name: 'ABC'}}
+        expect(response).to redirect_to(indicator_url(assigns(:indicator)))
+      end
     end
-  end
 
-  describe 'DELETE destroy' do
-    it 'redirects to index' do
-      delete :destroy, params: {id: indicator.id}
-      expect(response).to redirect_to(indicators_url)
+    describe 'GET edit' do
+      it 'renders edit' do
+        get :edit, params: {id: team_indicator.id}
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    describe 'PUT update' do
+      it 'renders edit when validation errors present' do
+        put :update, params: {id: team_indicator.id, indicator: {name: nil}}
+        expect(response).to render_template(:edit)
+      end
+
+      it 'redirects to indicator when successful' do
+        put :update, params: {id: team_indicator.id, indicator: {name: 'ABC'}}
+        expect(response).to redirect_to(indicator_url(team_indicator))
+      end
+    end
+
+    describe 'GET show' do
+      it 'renders show' do
+        get :show, params: {id: team_indicator.id}
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe 'DELETE destroy' do
+      it 'redirects to index' do
+        delete :destroy, params: {id: team_indicator.id}
+        expect(response).to redirect_to(indicators_url)
+      end
     end
   end
 end

--- a/spec/controllers/models_controller_spec.rb
+++ b/spec/controllers/models_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ModelsController, type: :controller do
       expect_any_instance_of(Model).to receive(:update_attributes).
         with(ActionController::Parameters.new(model_params).permit!)
       put :update, params: {
-        id: model.id,
+        id: team_model.id,
         model: model_params
       }
     end

--- a/spec/controllers/models_controller_spec.rb
+++ b/spec/controllers/models_controller_spec.rb
@@ -1,39 +1,90 @@
 require 'rails_helper'
 
 RSpec.describe ModelsController, type: :controller do
-  login_user
-  let(:team) { @user.team }
-  let!(:model) { FactoryGirl.create(:model, team: team) }
+  context 'when admin' do
+    login_admin
+    let!(:team_model) { FactoryGirl.create(:model, team: @user.team) }
+    let!(:some_model) { FactoryGirl.create(:model) }
 
-  describe 'GET index' do
-    it 'renders index when more than one model available' do
-      FactoryGirl.create(:model, team: team)
-      get :index
-      expect(response).to render_template(:index)
+    describe 'GET index' do
+      it 'lists all models' do
+        get :index
+        expect(assigns[:models].count).to eq(2)
+      end
     end
 
-    it 'redirects to model when only one model available' do
-      get :index
-      expect(response).to redirect_to(model_url(model))
+    describe 'GET show' do
+      it 'renders show' do
+        get :show, params: {id: some_model.id}
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe 'PUT update' do
+      it 'renders edit when validation errors present' do
+        put :update, params: {id: some_model.id, model: {abbreviation: nil}}
+        expect(response).to render_template(:edit)
+      end
+
+      it 'redirects to model when successful' do
+        put :update, params: {id: some_model.id, model: {abbreviation: 'ABC'}}
+        expect(response).to redirect_to(model_url(some_model))
+      end
     end
   end
 
-  describe 'GET show' do
-    it 'renders show' do
-      get :show, params: {id: model.id}
-      expect(response).to render_template(:show)
-    end
-  end
+  context 'when user' do
+    login_user
+    let!(:team_model) { FactoryGirl.create(:model, team: @user.team) }
+    let!(:some_model) { FactoryGirl.create(:model) }
 
-  describe 'PUT update' do
-    it 'renders edit when validation errors present' do
-      put :update, params: {id: model.id, model: {abbreviation: nil}}
-      expect(response).to render_template(:edit)
+    describe 'GET index' do
+      it 'lists all models available to the team' do
+        get :index
+        expect(assigns[:models].count).to eq(1)
+      end
+
+      it 'renders index when more than one model available' do
+        FactoryGirl.create(:model, team: @user.team)
+        get :index
+        expect(response).to render_template(:index)
+      end
+
+      it 'redirects to model when only one model available' do
+        get :index
+        expect(response).to redirect_to(model_url(team_model))
+      end
     end
 
-    it 'redirects to model when successful' do
-      put :update, params: {id: model.id, model: {abbreviation: 'ABC'}}
-      expect(response).to redirect_to(model_url(model))
+    describe 'GET show' do
+      it 'renders show' do
+        get :show, params: {id: team_model.id}
+        expect(response).to render_template(:show)
+      end
+
+      it 'prevents unauthorized access' do
+        get :show, params: {id: some_model.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
+    end
+
+    describe 'PUT update' do
+      it 'renders edit when validation errors present' do
+        put :update, params: {id: team_model.id, model: {abbreviation: nil}}
+        expect(response).to render_template(:edit)
+      end
+
+      it 'redirects to model when successful' do
+        put :update, params: {id: team_model.id, model: {abbreviation: 'ABC'}}
+        expect(response).to redirect_to(model_url(team_model))
+      end
+
+      it 'prevents unauthorized access' do
+        put :update, params: {id: some_model.id, model: {abbreviation: 'ABC'}}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
     end
 
     it 'filters parameters correctly for update' do

--- a/spec/controllers/scenarios_controller_spec.rb
+++ b/spec/controllers/scenarios_controller_spec.rb
@@ -1,44 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe ScenariosController, type: :controller do
-  login_user
-  let(:model) { FactoryGirl.create(:model) }
-  let!(:scenario) { FactoryGirl.create(:scenario, model: model) }
+  context 'when admin' do
+    login_admin
+    let(:team_model) { FactoryGirl.create(:model, team: @user.team) }
+    let(:some_model) { FactoryGirl.create(:model) }
+    let!(:team_scenario) { FactoryGirl.create(:scenario, model: team_model) }
+    let!(:some_scenario) { FactoryGirl.create(:scenario, model: some_model) }
 
-  describe 'GET index' do
-    it 'renders index' do
-      get :index, params: {model_id: model.id}
-      expect(response).to render_template(:index)
-    end
-  end
-
-  describe 'GET show' do
-    it 'renders show' do
-      get :show, params: {model_id: model.id, id: scenario.id}
-      expect(response).to render_template(:show)
-    end
-  end
-
-  describe 'GET edit' do
-    it 'renders edit' do
-      get :edit, params: {model_id: model.id, id: scenario.id}
-      expect(response).to render_template(:edit)
-    end
-  end
-
-  describe 'PUT update' do
-    it 'renders edit when validation errors present' do
-      put :update, params: {
-        model_id: model.id, id: scenario.id, scenario: {name: nil}
-      }
-      expect(response).to render_template(:edit)
+    describe 'GET index' do
+      it 'renders index' do
+        get :index, params: {model_id: some_model.id}
+        expect(response).to render_template(:index)
+      end
     end
 
-    it 'redirects to indicator when successful' do
-      put :update, params: {
-        model_id: model.id, id: scenario.id, scenario: {name: 'ABC'}
-      }
-      expect(response).to redirect_to(model_scenario_url(model, scenario))
+    describe 'GET show' do
+      it 'renders show' do
+        get :show, params: {model_id: some_model.id, id: some_scenario.id}
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe 'GET edit' do
+      it 'renders edit' do
+        get :edit, params: {model_id: some_model.id, id: some_scenario.id}
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    describe 'PUT update' do
+      it 'redirects to indicator when successful' do
+        put :update, params: {
+          model_id: some_model.id, id: some_scenario.id, scenario: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(
+          model_scenario_url(some_model, some_scenario)
+        )
+      end
+    end
+
+    describe 'DELETE destroy' do
+      it 'redirects to index' do
+        delete :destroy, params: {model_id: some_model.id, id: some_scenario.id}
+        expect(response).to redirect_to(model_scenarios_url(some_model))
+      end
     end
 
     it 'filters parameters correctly for update' do
@@ -57,10 +63,89 @@ RSpec.describe ScenariosController, type: :controller do
     end
   end
 
-  describe 'DELETE destroy' do
-    it 'redirects to index' do
-      delete :destroy, params: {model_id: model.id, id: scenario.id}
-      expect(response).to redirect_to(model_scenarios_url(model))
+  context 'when user' do
+    login_user
+    let(:team_model) { FactoryGirl.create(:model, team: @user.team) }
+    let(:some_model) { FactoryGirl.create(:model) }
+    let!(:team_scenario) { FactoryGirl.create(:scenario, model: team_model) }
+    let!(:some_scenario) { FactoryGirl.create(:scenario, model: some_model) }
+
+    describe 'GET index' do
+      it 'renders index' do
+        get :index, params: {model_id: team_model.id}
+        expect(response).to render_template(:index)
+      end
+
+      it 'prevents unauthorized access' do
+        get :index, params: {model_id: some_model.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
+    end
+
+    describe 'GET show' do
+      it 'renders show' do
+        get :show, params: {model_id: team_model.id, id: team_scenario.id}
+        expect(response).to render_template(:show)
+      end
+
+      it 'prevents unauthorized access' do
+        get :show, params: {model_id: some_model.id, id: some_scenario.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
+    end
+
+    describe 'GET edit' do
+      it 'renders edit' do
+        get :edit, params: {model_id: team_model.id, id: team_scenario.id}
+        expect(response).to render_template(:edit)
+      end
+
+      it 'prevents unauthorized access' do
+        get :edit, params: {model_id: some_model.id, id: some_scenario.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
+    end
+
+    describe 'PUT update' do
+      it 'renders edit when validation errors present' do
+        put :update, params: {
+          model_id: team_model.id, id: team_scenario.id, scenario: {name: nil}
+        }
+        expect(response).to render_template(:edit)
+      end
+
+      it 'redirects to indicator when successful' do
+        put :update, params: {
+          model_id: team_model.id, id: team_scenario.id, scenario: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(
+          model_scenario_url(team_model, team_scenario)
+        )
+      end
+
+      it 'prevents unauthorized access' do
+        put :update, params: {
+          model_id: some_model.id, id: some_scenario.id, scenario: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
+    end
+
+    describe 'DELETE destroy' do
+      it 'redirects to index' do
+        delete :destroy, params: {model_id: team_model.id, id: team_scenario.id}
+        expect(response).to redirect_to(model_scenarios_url(team_model))
+      end
+
+      it 'prevents unauthorized access' do
+        delete :destroy, params: {model_id: some_model.id, id: some_scenario.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
     end
   end
 end

--- a/spec/controllers/scenarios_controller_spec.rb
+++ b/spec/controllers/scenarios_controller_spec.rb
@@ -46,21 +46,6 @@ RSpec.describe ScenariosController, type: :controller do
         expect(response).to redirect_to(model_scenarios_url(some_model))
       end
     end
-
-    it 'filters parameters correctly for update' do
-      scenario_params = {
-        name: 'ABC',
-        technology_coverage: ['', 'A', 'B'],
-        category: ['', 'cat1']
-      }
-      expect_any_instance_of(Scenario).to receive(:update_attributes).
-        with(ActionController::Parameters.new(scenario_params).permit!)
-      put :update, params: {
-        model_id: model.id,
-        id: scenario.id,
-        scenario: scenario_params
-      }
-    end
   end
 
   context 'when user' do
@@ -146,6 +131,21 @@ RSpec.describe ScenariosController, type: :controller do
         expect(response).to redirect_to(root_url)
         expect(flash[:alert]).to match(/You are not authorized/)
       end
+    end
+
+    it 'filters parameters correctly for update' do
+      scenario_params = {
+        name: 'ABC',
+        technology_coverage: ['', 'A', 'B'],
+        category: ['', 'cat1']
+      }
+      expect_any_instance_of(Scenario).to receive(:update_attributes).
+        with(ActionController::Parameters.new(scenario_params).permit!)
+      put :update, params: {
+        model_id: team_model.id,
+        id: team_scenario.id,
+        scenario: scenario_params
+      }
     end
   end
 end

--- a/spec/controllers/team_users_controller_spec.rb
+++ b/spec/controllers/team_users_controller_spec.rb
@@ -1,36 +1,86 @@
 require 'rails_helper'
 
 RSpec.describe TeamUsersController, type: :controller do
-  login_admin
-
   let(:team) { FactoryGirl.create(:team) }
 
-  describe 'POST #create' do
-    context 'when new user' do
-      it 'creates a new user' do
-        expect {
-          post :create, params: {
-            team_id: team.id, user: {email: 'new_user@hello.com'}
-          }
-        }.to change(team.users, :count).by(1)
+  context 'when admin' do
+    login_admin
+
+    describe 'POST #create' do
+      context 'when new user' do
+        it 'creates a new user' do
+          expect {
+            post :create, params: {
+              team_id: team.id, user: {email: 'new_user@hello.com'}
+            }
+          }.to change(team.users, :count).by(1)
+        end
+      end
+      context 'when existing user' do
+        it 'does not create a new user' do
+          user = FactoryGirl.create(:user)
+          expect {
+            post :create, params: {team_id: team.id, user: {email: user.email}}
+          }.not_to change(team.users, :count)
+        end
       end
     end
-    context 'when existing user' do
-      it 'does not create a new user' do
-        user = FactoryGirl.create(:user)
+
+    describe 'DELETE #destroy' do
+      it 'destroys the user' do
+        user = FactoryGirl.create(:user, team: team)
         expect {
-          post :create, params: {team_id: team.id, user: {email: user.email}}
-        }.not_to change(team.users, :count)
+          delete :destroy, params: {team_id: team.id, id: user.id}
+        }.to change(team.users, :count).by(-1)
       end
     end
   end
 
-  describe 'DELETE #destroy' do
-    it 'destroys the user' do
-      user = FactoryGirl.create(:user, team: team)
-      expect {
+  context 'user' do
+    login_user
+
+    describe 'POST #create' do
+      context 'when new user' do
+        it 'creates a new user in user\'s team' do
+          expect {
+            post :create, params: {
+              team_id: @user.team.id, user: {email: 'new_user@hello.com'}
+            }
+          }.to change(@user.team.users, :count).by(1)
+        end
+        it 'prevents unauthorized access' do
+          post :create, params: {
+            team_id: team.id, user: {email: 'new_user@hello.com'}
+          }
+          expect(response).to redirect_to(root_url)
+          expect(flash[:alert]).to match(/You are not authorized/)
+        end
+      end
+      context 'when existing user' do
+        it 'does not create a new user' do
+          user = FactoryGirl.create(:user)
+          expect {
+            post :create, params: {
+              team_id: @user.team.id, user: {email: user.email}
+            }
+          }.not_to change(@user.team.users, :count)
+        end
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      it 'removes the user from user\'s team' do
+        user = FactoryGirl.create(:user, team: @user.team)
+        expect {
+          delete :destroy, params: {team_id: user.team_id, id: user.id}
+        }.to change(@user.team.users, :count).by(-1)
+      end
+      it 'prevents unauthorized access' do
+        user = FactoryGirl.create(:user, team: team)
         delete :destroy, params: {team_id: team.id, id: user.id}
-      }.to change(team.users, :count).by(-1)
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
     end
   end
 end

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -1,128 +1,193 @@
 require 'rails_helper'
 
 RSpec.describe TeamsController, type: :controller do
-  login_admin
+  context 'when admin' do
+    login_admin
 
-  describe 'GET #index' do
-    it 'assigns all teams as @teams' do
-      get :index
-      expect(assigns(:teams)).to eq([@user.team])
-    end
-  end
-
-  describe 'GET #new' do
-    it 'assigns a new team as @team' do
-      get :new
-      expect(assigns(:team)).to be_a_new(Team)
-    end
-    it 'assigns available models' do
-      FactoryGirl.create(:model, team: FactoryGirl.create(:team))
-      unassigned_model = FactoryGirl.build(:model, team: nil)
-      unassigned_model.save(validate: false)
-      get :new
-      expect(assigns(:models)).to eq([unassigned_model])
-    end
-  end
-
-  describe 'GET #edit' do
-    it 'assigns the requested team as @team' do
-      team = FactoryGirl.create(:team)
-      get :edit, params: {id: team.id}
-      expect(assigns(:team)).to eq(team)
-    end
-    it 'assigns available models' do
-      team = FactoryGirl.create(:team)
-      FactoryGirl.create(:model, team: FactoryGirl.create(:team))
-      unassigned_model = FactoryGirl.build(:model, team: nil)
-      unassigned_model.save(validate: false)
-      my_model = FactoryGirl.create(:model, team: team)
-      get :edit, params: {id: team.id}
-      expect(assigns(:models)).to eq([unassigned_model, my_model])
-    end
-  end
-
-  describe 'POST #create' do
-    context 'with valid params' do
-      it 'creates a new Team' do
-        expect {
-          post :create, params: {team: {name: 'New Name'}}
-        }.to change(Team, :count).by(1)
-      end
-
-      it 'assigns a newly created team as @team' do
-        post :create, params: {team: {name: 'New Name'}}
-        expect(assigns(:team)).to be_a(Team)
-        expect(assigns(:team)).to be_persisted
-      end
-
-      it 'redirects to the created team' do
-        post :create, params: {team: {name: 'New Name'}}
-        expect(response).to redirect_to(edit_team_url(Team.last))
+    describe 'GET #index' do
+      it 'assigns all teams as @teams' do
+        get :index
+        expect(assigns(:teams)).to eq([@user.team])
       end
     end
 
-    context 'with invalid params' do
-      it 'assigns a newly created but unsaved team as @team' do
-        post :create, params: {team: {name: nil}}
+    describe 'GET #new' do
+      it 'assigns a new team as @team' do
+        get :new
         expect(assigns(:team)).to be_a_new(Team)
       end
-
-      it 're-renders the edit template' do
-        post :create, params: {team: {name: nil}}
-        expect(response).to render_template('edit')
+      it 'assigns available models' do
+        FactoryGirl.create(:model, team: FactoryGirl.create(:team))
+        unassigned_model = FactoryGirl.build(:model, team: nil)
+        unassigned_model.save(validate: false)
+        get :new
+        expect(assigns(:models)).to eq([unassigned_model])
       end
     end
-  end
 
-  describe 'PUT #update' do
-    context 'with valid params' do
-      it 'updates the requested team' do
-        team = FactoryGirl.create(:team)
-        put :update, params: {id: team.to_param, team: {name: 'New Name'}}
-        team.reload
-        expect(team.name).to eq('New Name')
-      end
-
+    describe 'GET #edit' do
       it 'assigns the requested team as @team' do
         team = FactoryGirl.create(:team)
-        put :update, params: {id: team.to_param, team: {name: 'New Name'}}
+        get :edit, params: {id: team.id}
         expect(assigns(:team)).to eq(team)
       end
-
-      it 'redirects to the team' do
+      it 'assigns available models' do
         team = FactoryGirl.create(:team)
-        put :update, params: {id: team.to_param, team: {name: 'New Name'}}
-        expect(response).to redirect_to(edit_team_url(team))
+        FactoryGirl.create(:model, team: FactoryGirl.create(:team))
+        unassigned_model = FactoryGirl.build(:model, team: nil)
+        unassigned_model.save(validate: false)
+        my_model = FactoryGirl.create(:model, team: team)
+        get :edit, params: {id: team.id}
+        expect(assigns(:models)).to eq([unassigned_model, my_model])
       end
     end
 
-    context 'with invalid params' do
-      it 'assigns the team as @team' do
-        team = FactoryGirl.create(:team)
-        put :update, params: {id: team.to_param, team: {name: nil}}
-        expect(assigns(:team)).to eq(team)
+    describe 'POST #create' do
+      context 'with valid params' do
+        it 'creates a new Team' do
+          expect {
+            post :create, params: {team: {name: 'New Name'}}
+          }.to change(Team, :count).by(1)
+        end
+
+        it 'assigns a newly created team as @team' do
+          post :create, params: {team: {name: 'New Name'}}
+          expect(assigns(:team)).to be_a(Team)
+          expect(assigns(:team)).to be_persisted
+        end
+
+        it 'redirects to the created team' do
+          post :create, params: {team: {name: 'New Name'}}
+          expect(response).to redirect_to(edit_team_url(Team.last))
+        end
       end
 
-      it 're-renders the edit template' do
+      context 'with invalid params' do
+        it 'assigns a newly created but unsaved team as @team' do
+          post :create, params: {team: {name: nil}}
+          expect(assigns(:team)).to be_a_new(Team)
+        end
+
+        it 're-renders the edit template' do
+          post :create, params: {team: {name: nil}}
+          expect(response).to render_template('edit')
+        end
+      end
+    end
+
+    describe 'PUT #update' do
+      context 'with valid params' do
+        it 'updates the requested team' do
+          team = FactoryGirl.create(:team)
+          put :update, params: {id: team.id, team: {name: 'New Name'}}
+          team.reload
+          expect(team.name).to eq('New Name')
+        end
+
+        it 'assigns the requested team as @team' do
+          team = FactoryGirl.create(:team)
+          put :update, params: {id: team.id, team: {name: 'New Name'}}
+          expect(assigns(:team)).to eq(team)
+        end
+
+        it 'redirects to the team' do
+          team = FactoryGirl.create(:team)
+          put :update, params: {id: team.id, team: {name: 'New Name'}}
+          expect(response).to redirect_to(edit_team_url(team))
+        end
+      end
+
+      context 'with invalid params' do
+        it 'assigns the team as @team' do
+          team = FactoryGirl.create(:team)
+          put :update, params: {id: team.id, team: {name: nil}}
+          expect(assigns(:team)).to eq(team)
+        end
+
+        it 're-renders the edit template' do
+          team = FactoryGirl.create(:team)
+          put :update, params: {id: team.id, team: {name: nil}}
+          expect(response).to render_template('edit')
+        end
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      it 'destroys the requested team' do
         team = FactoryGirl.create(:team)
-        put :update, params: {id: team.to_param, team: {name: nil}}
-        expect(response).to render_template('edit')
+        expect {
+          delete :destroy, params: {id: team.id}
+        }.to change(Team, :count).by(-1)
+      end
+
+      it 'redirects to the teams list' do
+        team = FactoryGirl.create(:team)
+        delete :destroy, params: {id: team.id}
+        expect(response).to redirect_to(teams_url)
       end
     end
   end
 
-  describe 'DELETE #destroy' do
-    it 'destroys the requested team' do
-      team = FactoryGirl.create(:team)
-      expect {
-        delete :destroy, params: {id: team.to_param}
-      }.to change(Team, :count).by(-1)
+  context 'when user' do
+    login_user
+
+    describe 'GET #index' do
+      it 'prevents unauthorized access' do
+        get :index
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
     end
 
-    it 'redirects to the teams list' do
-      team = FactoryGirl.create(:team)
-      delete :destroy, params: {id: team.to_param}
-      expect(response).to redirect_to(teams_url)
+    describe 'GET #new' do
+      it 'prevents unauthorized access' do
+        get :new
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
+    end
+
+    describe 'GET #edit' do
+      it 'assigns user\'s team as @team' do
+        get :edit, params: {id: @user.team.id}
+        expect(assigns(:team)).to eq(@user.team)
+      end
+      it 'prevents unauthorized access' do
+        team = FactoryGirl.create(:team)
+        get :edit, params: {id: team.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
+    end
+
+    describe 'POST #create' do
+      it 'prevents unauthorized access' do
+        post :create, params: {team: {name: 'New Name'}}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
+    end
+
+    describe 'PUT #update' do
+      it 'updates user\'s team' do
+        put :update, params: {id: @user.team_id, team: {name: 'New Name'}}
+        expect(@user.team.reload.name).to eq('New Name')
+      end
+      it 'prevents unauthorized access' do
+        team = FactoryGirl.create(:team)
+        put :update, params: {id: team.id, team: {name: 'New Name'}}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      it 'prevents unauthorized access' do
+        team = FactoryGirl.create(:team)
+        delete :destroy, params: {id: team.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
     end
   end
 end

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -5,9 +5,8 @@ RSpec.describe TeamsController, type: :controller do
 
   describe 'GET #index' do
     it 'assigns all teams as @teams' do
-      team = FactoryGirl.create(:team)
       get :index
-      expect(assigns(:teams)).to eq([team])
+      expect(assigns(:teams)).to eq([@user.team])
     end
   end
 

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :model do
-    full_name { Faker::App.name }
-    sequence(:abbreviation) { |n| full_name[0..5] + n.to_s }
+    sequence(:full_name) { |n| "#{n} " + Faker::App.name }
+    abbreviation { full_name[0..10] }
     team
   end
 end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Model, type: :model do
       FactoryGirl.build(:model, abbreviation: 'A-Team')
     ).to have(1).errors_on(:abbreviation)
   end
-  it 'should be invalid when team not present' do
+  pending 'should be invalid when team not present (?)' do
     expect(
       FactoryGirl.build(:model, team: nil)
     ).to have(1).errors_on(:team)

--- a/spec/services/upload_time_series_values_spec.rb
+++ b/spec/services/upload_time_series_values_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe UploadTimeSeriesValues do
+  let(:user) { FactoryGirl.create(:user) }
   let(:model) { FactoryGirl.create(:model, abbreviation: 'Model A') }
   let!(:scenario) {
     FactoryGirl.create(:scenario, name: 'Scenario 1', model: model)
@@ -17,8 +18,7 @@ RSpec.describe UploadTimeSeriesValues do
   let!(:location) {
     FactoryGirl.create(:location, name: 'Poland', iso_code2: 'PL')
   }
-  # TODO: current user
-  subject { UploadTimeSeriesValues.new(nil, model).call(file) }
+  subject { UploadTimeSeriesValues.new(user, model).call(file) }
 
   context 'when file correct' do
     let(:file) {

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -2,8 +2,8 @@ module ControllerMacros
   def login_admin
     before(:each) do
       @request.env['devise.mapping'] = Devise.mappings[:user]
-      @admin = FactoryGirl.create(:user, admin: true, team: nil)
-      sign_in @admin
+      @user = FactoryGirl.create(:user, admin: true)
+      sign_in @user
     end
   end
 


### PR DESCRIPTION
Adds authorisation checks and specs for currently existing objects in the system using `CanCanCan`. In case of access denied redirects to the home page with a flash alert.
Indicators will require more work once the per-model indicators. Also the batch upload actions will require additional checks once implemented.