### PR TITLE
Same url '/' for user & admin root

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,12 +21,4 @@ class ApplicationController < ActionController::Base
       :type
     )
   end
-
-  def after_sign_in_path_for(user)
-    if user.admin?
-      admin_root_path
-    else
-      root_path
-    end
-  end
 end

--- a/app/views/shared/components/_c_landing_header.html.erb
+++ b/app/views/shared/components/_c_landing_header.html.erb
@@ -12,7 +12,7 @@
         <% if title.present? %>
           <%= title %>
         <% else %>
-          Emission Scenarios Portal
+          <%= link_to 'Emission Scenarios Portal', '/' %>
         <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,9 @@ Rails.application.routes.draw do
     resources :users, only: [:create, :destroy], controller: 'team_users'
   end
 
-  scope :admin do
-    root to: 'admin#home', as: :admin_root
-  end
-  root to: 'models#index'
+  # Rails routes are matched in the order they are specified
+  root to: "admin#home",
+    constraints: lambda { |request| request.env['warden'].user.try(:admin?) },
+    as: :admin_root
+  root to: "models#index"
 end


### PR DESCRIPTION
Amended the routes so that '/' takes the admin / modeller to their respective homepages + adds a link to '/' on the ESP logo.