### PR TITLE
Nest indicators under models

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,14 +12,18 @@ class ApplicationController < ActionController::Base
   private
 
   def set_nav_links
+    return unless @model.present?
     @nav_links = [
       {name: 'Overview', path: model_url(@model), key: 'models'},
-      {name: 'Scenarios', path: model_scenarios_url(@model), key: 'scenarios'},
+      {
+        name: 'Scenarios',
+        path: model_scenarios_url(@model), key: 'scenarios'
+      },
       {
         name: 'Indicators',
         path: model_indicators_url(@model), key: 'indicators'
       }
-    ] if @model.present?
+    ]
   end
 
   def set_filter_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,10 @@ class ApplicationController < ActionController::Base
     @nav_links = [
       {name: 'Overview', path: model_url(@model), key: 'models'},
       {name: 'Scenarios', path: model_scenarios_url(@model), key: 'scenarios'},
-      {name: 'Indicators', path: indicators_url(@model), key: 'indicators'}
+      {
+        name: 'Indicators',
+        path: model_indicators_url(@model), key: 'indicators'
+      }
     ] if @model.present?
   end
 

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -3,6 +3,7 @@ class IndicatorsController < ApplicationController
   load_resource except: [:new, :create, :index]
   authorize_resource through: :model
 
+  before_action :set_nav_links, only: [:index, :show, :edit]
   before_action :set_filter_params, only: [:index]
 
   def index

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -1,9 +1,7 @@
 class IndicatorsController < ApplicationController
-  # TODO: once per-model indicators in place
-  # load_and_authorize_resource :model
-  # load_and_authorize_resource through: :model, except: [:index]
-  load_and_authorize_resource except: [:index]
-  authorize_resource only: [:index]
+  load_and_authorize_resource :model
+  load_resource except: [:new, :create, :index]
+  authorize_resource through: :model
 
   before_action :set_filter_params, only: [:index]
 
@@ -15,14 +13,14 @@ class IndicatorsController < ApplicationController
   end
 
   def new
-    @indicator = Indicator.new
+    @indicator = Indicator.new(model: @model)
     render action: :edit
   end
 
   def create
     @indicator = Indicator.new(indicator_params)
     if @indicator.save
-      redirect_to indicator_url(@indicator)
+      redirect_to model_indicator_url(@model, @indicator)
     else
       render action: :edit
     end
@@ -32,7 +30,7 @@ class IndicatorsController < ApplicationController
 
   def update
     if @indicator.update_attributes(indicator_params)
-      redirect_to indicator_url(@indicator)
+      redirect_to model_indicator_url(@model, @indicator)
     else
       render action: :edit
     end
@@ -42,7 +40,10 @@ class IndicatorsController < ApplicationController
 
   def destroy
     @indicator.destroy
-    redirect_to indicators_url, notice: 'Indicator successfully destroyed'
+    redirect_to(
+      model_indicators_url(@model),
+      notice: 'Indicator successfully destroyed'
+    )
   end
 
   def upload_meta_data

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -19,6 +19,7 @@ class IndicatorsController < ApplicationController
 
   def create
     @indicator = Indicator.new(indicator_params)
+    @indicator.model = @model unless current_user.admin?
     if @indicator.save
       redirect_to model_indicator_url(@model, @indicator)
     else
@@ -29,6 +30,9 @@ class IndicatorsController < ApplicationController
   def edit; end
 
   def update
+    # If this is a researcher trying to update a master indicator
+    # fork the indicator
+    create and return if !current_user.admin? && @indicator.model.nil?
     if @indicator.update_attributes(indicator_params)
       redirect_to model_indicator_url(@model, @indicator)
     else

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,6 +16,9 @@ class Ability
       can :edit, Indicator do |indicator|
         indicator.model_id.nil?
       end
+      can :update, Indicator do |indicator|
+        indicator.model_id.nil?
+      end
       can :manage, Indicator do |indicator|
         team.models.pluck(:id).include?(indicator.model_id)
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,8 +10,15 @@ class Ability
     else
       can :manage, Model, team_id: team.id
       can :manage, Scenario, model: {team_id: team.id}
-      # TODO: finalize when per-model indicators in place
-      can :manage, Indicator
+      can :read, Indicator do |indicator|
+        indicator.model_id.nil?
+      end
+      can :edit, Indicator do |indicator|
+        indicator.model_id.nil?
+      end
+      can :manage, Indicator do |indicator|
+        team.models.pluck(:id).include?(indicator.model_id)
+      end
       can :show, Team, id: team.id
       can :edit, Team, id: team.id
       can :update, Team, id: team.id

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -7,6 +7,7 @@ class Indicator < ApplicationRecord
   ORDERS = %w[name category stack_family definition unit].freeze
 
   has_many :time_series_values, dependent: :destroy
+  belongs_to :model, optional: true
 
   validates :name, presence: true
 

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -10,6 +10,7 @@ class Indicator < ApplicationRecord
   belongs_to :model, optional: true
 
   validates :name, presence: true
+  before_validation :ignore_blank_array_values
 
   def scenarios
     Scenario.joins(

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -6,6 +6,7 @@ class Model < ApplicationRecord
 
   belongs_to :team
   has_many :scenarios, dependent: :restrict_with_error
+  has_many :indicators, dependent: :restrict_with_error
 
   validates :abbreviation, presence: true, uniqueness: true
   validates :full_name, presence: true

--- a/app/views/indicators/edit.html.erb
+++ b/app/views/indicators/edit.html.erb
@@ -2,13 +2,13 @@
   title: @indicator.name,
   no_settings: true %>
 
-<%= form_for @indicator do |f| %>
+<%= form_for [@model, @indicator] do |f| %>
   <div class="l-indicator-edit">
     <div class="row">
       <div class="small-12 columns">
         <div class="row align-right">
           <div class="small-2 columns">
-            <%= link_to indicators_url, class: 'l-indicator-edit__form-action' do %>
+            <%= link_to model_indicators_url(@model), class: 'l-indicator-edit__form-action' do %>
               <%= render 'shared/components/c_flying_button' %>
             <% end %>
           </div>

--- a/app/views/indicators/index.html.erb
+++ b/app/views/indicators/index.html.erb
@@ -8,7 +8,7 @@
       <div class="f-ff3-m-bold">Indicators <span>(<%= @indicators.count %>)</span></div>
     </div>
     <div class="small-3 columns">
-      <%= link_to new_indicator_url, class: 'l-indicators__new-indicator' do %>
+      <%= link_to new_model_indicator_url(@model), class: 'l-indicators__new-indicator' do %>
         <div class="c-hollow-button"><span>Create new indicator</span></div>
       <% end %>
     </div>
@@ -94,7 +94,7 @@
       <div class="c-table-list-item">
         <div class="row">
           <div class="small-2 columns">
-            <div class="c-table-list-item__text f-ff1-m-bold"><%= link_to indicator.name, indicator_url(indicator) %></div>
+            <div class="c-table-list-item__text f-ff1-m-bold"><%= link_to indicator.name, model_indicator_url(@model, indicator) %></div>
           </div>
           <div class="small-2 columns">
             <div class="c-table-list-item__text f-ff1-m"><%= indicator.category %></div>
@@ -112,12 +112,12 @@
           </div>
           <div class="small-1 columns">
             <div class="c-table-list-item__actions">
-              <%= link_to indicator_url(indicator), method: :delete, data: {confirm: destroy_confirmation_message(indicator)} do %>
+              <%= link_to model_indicator_url(@model, indicator), method: :delete, data: {confirm: destroy_confirmation_message(indicator)} do %>
                 <div class="c-delete-button">
                   <svg class="icon"><use xlink:href="#icon-delete"></use></svg>
                 </div>
               <% end %>
-              <%= link_to edit_indicator_url(indicator) do %>
+              <%= link_to edit_model_indicator_url(@model, indicator) do %>
                 <div class="c-edit-button">
                   <svg class="icon"><use xlink:href="#icon-edit"></use></svg>
                 </div>

--- a/app/views/indicators/index.html.erb
+++ b/app/views/indicators/index.html.erb
@@ -1,7 +1,6 @@
 <%= render 'shared/components/c_landing_header',
   title: 'GCAM. Global Change Assessment Model',
-  no_settings: true,
-  no_nav: true %>
+  no_settings: true %>
 <div class="l-indicators">
   <div class="row align-justify">
     <div class="small-5 columns">

--- a/app/views/indicators/show.html.erb
+++ b/app/views/indicators/show.html.erb
@@ -1,7 +1,6 @@
 <%= render 'shared/components/c_landing_header',
   title: 'GCAM. Global Change Assessment Model',
-  no_settings: true,
-  no_nav: true %>
+  no_settings: true %>
 <div class="l-indicators-overview">
   <div class="l-indicators-overview__data-block">
     <div class="row">

--- a/app/views/indicators/show.html.erb
+++ b/app/views/indicators/show.html.erb
@@ -28,7 +28,7 @@
         <div class="f-ff1-m l-indicators-overview__data"><%= @indicator.definition %></div>
       </div>
       <div class="small-1 columns">
-        <%= link_to edit_indicator_url(@indicator) do %>
+        <%= link_to edit_model_indicator_url(@model, @indicator) do %>
           <div class="c-edit-button">
             <svg class="icon"><use xlink:href="#icon-edit"></use></svg>
           </div>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -14,7 +14,7 @@
       <%= render 'shared/components/c_model_overview_card',
         title: 'Indicators',
         values: @indicators,
-        button_url: indicators_url(@model)
+        button_url: model_indicators_url(@model)
       %>
     </div>
     <div class="small-4 columns">

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -96,7 +96,7 @@
       <div class="c-table-list-item">
         <div class="row">
           <div class="small-2 columns">
-            <div class="c-table-list-item__text f-ff1-m-bold"><%= link_to indicator.name, indicator_url(indicator) %></div>
+            <div class="c-table-list-item__text f-ff1-m-bold"><%= link_to indicator.name, model_indicator_url(@model, indicator) %></div>
           </div>
           <div class="small-2 columns">
             <div class="c-table-list-item__text f-ff1-m"><%= indicator.unit %></div>
@@ -111,12 +111,12 @@
           </div>
           <div class="small-1 columns">
             <div class="c-table-list-item__actions">
-              <%= link_to indicator_url(indicator), method: :delete, data: {confirm: destroy_confirmation_message(indicator)} do %>
+              <%= link_to model_indicator_url(@model, indicator), method: :delete, data: {confirm: destroy_confirmation_message(indicator)} do %>
                 <div class="c-delete-button">
                   <svg class="icon"><use xlink:href="#icon-delete"></use></svg>
                 </div>
               <% end %>
-              <%= link_to edit_indicator_url(indicator) do %>
+              <%= link_to edit_model_indicator_url(@model, indicator) do %>
                 <div class="c-edit-button">
                   <svg class="icon"><use xlink:href="#icon-edit"></use></svg>
                 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,10 +9,11 @@ Rails.application.routes.draw do
       post :upload_meta_data, on: :collection
       post :upload_time_series, on: :collection, to: 'time_series_values#upload', as: :upload_time_series
     end
+    resources :indicators, only: [:index, :show, :new, :create, :edit, :update, :destroy] do
+      post :upload_meta_data, on: :collection#, as: :upload_indicators_meta_data
+    end
   end
-  resources :indicators, only: [:index, :show, :new, :create, :edit, :update, :destroy] do
-    post :upload_meta_data, on: :collection#, as: :upload_indicators_meta_data
-  end
+
   resources :teams, except: [:show] do
     resources :users, only: [:create, :destroy], controller: 'team_users'
   end

--- a/db/migrate/20170525102655_add_model_to_indicators.rb
+++ b/db/migrate/20170525102655_add_model_to_indicators.rb
@@ -1,0 +1,5 @@
+class AddModelToIndicators < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :indicators, :model, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170522115509) do
+ActiveRecord::Schema.define(version: 20170525102655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 20170522115509) do
     t.text     "notes"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.integer  "model_id"
+    t.index ["model_id"], name: "index_indicators_on_model_id", using: :btree
   end
 
   create_table "locations", force: :cascade do |t|
@@ -184,6 +186,7 @@ ActiveRecord::Schema.define(version: 20170522115509) do
     t.index ["team_id"], name: "index_users_on_team_id", using: :btree
   end
 
+  add_foreign_key "indicators", "models"
   add_foreign_key "models", "teams"
   add_foreign_key "scenarios", "models"
   add_foreign_key "time_series_values", "indicators"

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -5,94 +5,286 @@ RSpec.describe IndicatorsController, type: :controller do
     login_admin
     let(:team_model) { FactoryGirl.create(:model, team: @user.team) }
     let(:some_model) { FactoryGirl.create(:model) }
-    let(:team_indicator) {
-      i = FactoryGirl.create(:indicator)
-      s = FactoryGirl.create(:scenario, model: team_model)
-      FactoryGirl.create(:time_series_value, indicator: i, scenario: s)
-      i
-    }
-    let(:some_indicator) {
-      i = FactoryGirl.create(:indicator)
-      s = FactoryGirl.create(:scenario, model: some_model)
-      FactoryGirl.create(:time_series_value, indicator: i, scenario: s)
-      i
-    }
-    pending 'add more specs when per-model indicators in place'
+    let(:team_indicator) { FactoryGirl.create(:indicator, model: team_model) }
+    let(:some_indicator) { FactoryGirl.create(:indicator, model: some_model) }
+    let(:master_indicator) { FactoryGirl.create(:indicator, model: nil) }
+
+    describe 'GET index' do
+      it 'assigns all indicators for own team\'s model' do
+        get :index, params: {model_id: team_model.id}
+        expect(assigns(:indicators)).to eq(
+          [team_indicator, some_indicator, master_indicator]
+        )
+      end
+      it 'assigns all indicators for other team\'s model' do
+        get :index, params: {model_id: some_model.id}
+        expect(assigns(:indicators)).to eq(
+          [team_indicator, some_indicator, master_indicator]
+        )
+      end
+    end
+
+    describe 'GET new' do
+      it 'renders edit for own team\'s model' do
+        get :new, params: {model_id: team_model.id}
+        expect(response).to render_template(:edit)
+      end
+      it 'renders edit for other team\'s model' do
+        get :new, params: {model_id: some_model.id}
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    describe 'POST create' do
+      it 'redirects to own team\'s indicator when successful' do
+        post :create, params: {
+          model_id: team_model.id, indicator: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(
+          model_indicator_url(team_model, assigns(:indicator))
+        )
+      end
+
+      it 'redirects to other team\'s indicator when successful' do
+        post :create, params: {
+          model_id: some_model.id, indicator: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(
+          model_indicator_url(some_model, assigns(:indicator))
+        )
+      end
+    end
+
+    describe 'GET edit' do
+      it 'renders edit for own team\'s indicator' do
+        get :edit, params: {model_id: team_model.id, id: team_indicator.id}
+        expect(response).to render_template(:edit)
+      end
+
+      it 'renders edit for master indicator' do
+        get :edit, params: {model_id: some_model.id, id: master_indicator.id}
+        expect(response).to render_template(:edit)
+      end
+
+      it 'renders edit for other team\'s indicator' do
+        get :edit, params: {model_id: some_model.id, id: some_indicator.id}
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    describe 'PUT update' do
+      it 'redirects to own team\'s indicator when successful' do
+        put :update, params: {
+          model_id: team_model.id,
+          id: team_indicator.id,
+          indicator: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(
+          model_indicator_url(team_model, team_indicator)
+        )
+      end
+
+      it 'redirects to other team\'s indicator when successful' do
+        put :update, params: {
+          model_id: some_model.id,
+          id: some_indicator.id,
+          indicator: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(
+          model_indicator_url(some_model, some_indicator)
+        )
+      end
+    end
+
+    describe 'GET show' do
+      it 'renders show for own team\'s indicator' do
+        get :show, params: {model_id: team_model.id, id: team_indicator.id}
+        expect(response).to render_template(:show)
+      end
+
+      it 'renders show for master indicator' do
+        get :show, params: {model_id: team_model.id, id: master_indicator.id}
+        expect(response).to render_template(:show)
+      end
+
+      it 'renders show for other team\'s indicator' do
+        get :show, params: {model_id: some_model.id, id: some_indicator.id}
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe 'DELETE destroy' do
+      it 'redirects to index for own team\'s indicator' do
+        delete :destroy, params: {
+          model_id: team_model.id, id: team_indicator.id
+        }
+        expect(response).to redirect_to(model_indicators_url(team_model))
+      end
+
+      it 'redirects to index for master indicator' do
+        delete :destroy, params: {
+          model_id: team_model.id, id: master_indicator.id
+        }
+        expect(response).to redirect_to(model_indicators_url(team_model))
+      end
+
+      it 'redirects to index for other team\'s indicator' do
+        delete :destroy, params: {
+          model_id: some_model.id, id: some_indicator.id
+        }
+        expect(response).to redirect_to(model_indicators_url(some_model))
+      end
+    end
   end
 
   context 'when user' do
     login_user
     let(:team_model) { FactoryGirl.create(:model, team: @user.team) }
     let(:some_model) { FactoryGirl.create(:model) }
-    let(:team_indicator) {
-      i = FactoryGirl.create(:indicator)
-      s = FactoryGirl.create(:scenario, model: team_model)
-      FactoryGirl.create(:time_series_value, indicator: i, scenario: s)
-      i
-    }
-    let(:some_indicator) {
-      i = FactoryGirl.create(:indicator)
-      s = FactoryGirl.create(:scenario, model: some_model)
-      FactoryGirl.create(:time_series_value, indicator: i, scenario: s)
-      i
-    }
+    let(:team_indicator) { FactoryGirl.create(:indicator, model: team_model) }
+    let(:some_indicator) { FactoryGirl.create(:indicator, model: some_model) }
+    let(:master_indicator) { FactoryGirl.create(:indicator, model: nil) }
 
     describe 'GET index' do
       it 'renders index' do
-        get :index
+        get :index, params: {model_id: team_model.id}
         expect(response).to render_template(:index)
+      end
+      it 'assigns team and master indicators' do
+        get :index, params: {model_id: team_model.id}
+        expect(assigns(:indicators)).to eq([team_indicator, master_indicator])
+      end
+      it 'prevents unauthorized access' do
+        get :index, params: {model_id: some_model.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
       end
     end
 
     describe 'GET new' do
-      it 'renders edit' do
-        get :new
+      it 'renders edit for own team\'s model' do
+        get :new, params: {model_id: team_model.id}
         expect(response).to render_template(:edit)
+      end
+      it 'prevents unauthorized access' do
+        get :new, params: {model_id: some_model.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
       end
     end
 
     describe 'POST create' do
       it 'renders edit when validation errors present' do
-        post :create, params: {indicator: {name: nil}}
+        post :create, params: {model_id: team_model.id, indicator: {name: nil}}
         expect(response).to render_template(:edit)
       end
 
       it 'redirects to indicator when successful' do
-        post :create, params: {indicator: {name: 'ABC'}}
-        expect(response).to redirect_to(indicator_url(assigns(:indicator)))
+        post :create, params: {
+          model_id: team_model.id, indicator: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(
+          model_indicator_url(team_model, assigns(:indicator))
+        )
+      end
+
+      it 'prevents unauthorized access' do
+        post :create, params: {
+          model_id: some_model.id, indicator: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
       end
     end
 
     describe 'GET edit' do
-      it 'renders edit' do
-        get :edit, params: {id: team_indicator.id}
+      it 'renders edit for own team\'s indicator' do
+        get :edit, params: {model_id: team_model.id, id: team_indicator.id}
         expect(response).to render_template(:edit)
+      end
+
+      it 'renders edit for master indicator' do
+        get :edit, params: {model_id: team_model.id, id: master_indicator.id}
+        expect(response).to render_template(:edit)
+      end
+
+      it 'prevents unauthorized access' do
+        get :edit, params: {model_id: some_model.id, id: some_indicator.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
       end
     end
 
     describe 'PUT update' do
       it 'renders edit when validation errors present' do
-        put :update, params: {id: team_indicator.id, indicator: {name: nil}}
+        put :update, params: {
+          model_id: team_model.id, id: team_indicator.id, indicator: {name: nil}
+        }
         expect(response).to render_template(:edit)
       end
 
       it 'redirects to indicator when successful' do
-        put :update, params: {id: team_indicator.id, indicator: {name: 'ABC'}}
-        expect(response).to redirect_to(indicator_url(team_indicator))
+        put :update, params: {
+          model_id: team_model.id,
+          id: team_indicator.id,
+          indicator: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(
+          model_indicator_url(team_model, team_indicator)
+        )
+      end
+
+      it 'prevents unauthorized access' do
+        put :update, params: {
+          model_id: some_model.id,
+          id: some_indicator.id,
+          indicator: {name: 'ABC'}
+        }
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
       end
     end
 
     describe 'GET show' do
       it 'renders show' do
-        get :show, params: {id: team_indicator.id}
+        get :show, params: {model_id: team_model.id, id: team_indicator.id}
         expect(response).to render_template(:show)
+      end
+
+      it 'renders show' do
+        get :show, params: {model_id: team_model.id, id: master_indicator.id}
+        expect(response).to render_template(:show)
+      end
+
+      it 'prevents unauthorized access' do
+        get :show, params: {model_id: some_model.id, id: some_indicator.id}
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
       end
     end
 
     describe 'DELETE destroy' do
       it 'redirects to index' do
-        delete :destroy, params: {id: team_indicator.id}
-        expect(response).to redirect_to(indicators_url)
+        delete :destroy, params: {
+          model_id: team_model.id, id: team_indicator.id
+        }
+        expect(response).to redirect_to(model_indicators_url(team_model))
+      end
+
+      it 'prevents unauthorized access' do
+        delete :destroy, params: {
+          model_id: team_model.id, id: master_indicator.id
+        }
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
+      end
+
+      it 'prevents unauthorized access' do
+        delete :destroy, params: {
+          model_id: some_model.id, id: some_indicator.id
+        }
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to match(/You are not authorized/)
       end
     end
   end

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -94,6 +94,16 @@ RSpec.describe IndicatorsController, type: :controller do
           model_indicator_url(some_model, some_indicator)
         )
       end
+
+      it ' does not create a model-specific copy of a master indicator' do
+        expect {
+          put :update, params: {
+            model_id: team_model.id,
+            id: master_indicator.id,
+            indicator: {name: 'ABC'}
+          }
+        }.not_to change(team_model.indicators, :count)
+      end
     end
 
     describe 'GET show' do
@@ -242,6 +252,16 @@ RSpec.describe IndicatorsController, type: :controller do
         }
         expect(response).to redirect_to(root_url)
         expect(flash[:alert]).to match(/You are not authorized/)
+      end
+
+      it 'creates a model-specific copy of a master indicator' do
+        expect {
+          put :update, params: {
+            model_id: team_model.id,
+            id: master_indicator.id,
+            indicator: {name: 'ABC'}
+          }
+        }.to change(team_model.indicators, :count).by(1)
       end
     end
 


### PR DESCRIPTION
Indicators may now be linked to models. When a modeller edits an indicator which is not yet linked to a model, the system transparently forks the indicator and links the copy to the current model. Permissions are set up so that researchers can:
- read, create, edit, update, delete their team's indicators
- read, edit and update indicators that have not been linked with a model,  but the "forking" update behaviour ensures they cannot actually overwrite a "master indicator"

I think it's worth to merge this because it sorts out the indicator paths (with the`model/x/` prefix), even if there's more work on indicators schema in the pipeline.