### PR TITLE
Fix/root link

### DIFF
--- a/app/views/shared/components/_c_landing_header.html.erb
+++ b/app/views/shared/components/_c_landing_header.html.erb
@@ -10,7 +10,7 @@
     <div class="small-9 columns">
       <div class="f-ff2-xl-extralight c-landing-header__title">
         <% if title.present? %>
-          <%= title %>
+          <%= link_to 'ESP', '/' %> > <%= title %>
         <% else %>
           <%= link_to 'Emission Scenarios Portal', '/' %>
         <% end %>

--- a/app/views/shared/components/_c_wri_header.html.erb
+++ b/app/views/shared/components/_c_wri_header.html.erb
@@ -1,3 +1,5 @@
 <div class="c-wri-header">
-  <svg class="icon"><use xlink:href="#icon-WRI"></use></svg>
+  <%= link_to 'http://www.wri.org' do %>
+    <svg class="icon"><use xlink:href="#icon-WRI"></use></svg>
+  <% end %>
 </div>


### PR DESCRIPTION
WRI logo links to WRI page, 'Emissions Scenario Portal' links to root, when in model pages and ESP slug is prepended to the title of the page which acts as a home link.