### PR TITLE
feature/prevent-jsreload

### DIFF
--- a/app/assets/javascripts/views/filters_view.js
+++ b/app/assets/javascripts/views/filters_view.js
@@ -9,7 +9,7 @@
     initialize: function(settings) {
       var opts = settings && settings.options ? settings.options : {};
       this.options = _.extend({}, this.options, opts);
-      this.staticParams = typeof settings.staticParams !== "undefined" ? settings.staticParams : null;
+      this.staticParams = typeof settings.staticParams !== 'undefined' ? settings.staticParams : null;
 
       this._cache();
       this._loadFilters();
@@ -18,23 +18,23 @@
 
     _cache: function() {
       this.$filters = $('.js-table-filter');
+      this.filters = [];
     },
 
     _loadFilters: function() {
-      this.filters = [];
       _.each(this.$filters, function(item) {
         var filter = $(item);
-        switch (filter.data("filter-type")) {
-          case "order":
+        switch (filter.data('filter-type')) {
+          case 'order':
             this._loadOrder(this._getHelperFilterObject(filter));
             break;
-          case "search":
+          case 'search':
             this._loadSearch(this._getHelperFilterObject(filter));
             break;
-          case "select":
+          case 'select':
             this._loadSelect(this._getHelperFilterObject(filter));
             break;
-          case "multiselect":
+          case 'multiselect':
             this._loadMultiselect(this._getHelperFilterObject(filter));
             break;
         }

--- a/app/assets/javascripts/views/form_view.js
+++ b/app/assets/javascripts/views/form_view.js
@@ -17,6 +17,7 @@
 
     initialize: function() {
       this._cache();
+      this._cleanSelect2();
       this._loadSelect();
       this._loadMultisingleSelect();
       this._loadMultipleSelect();
@@ -27,7 +28,12 @@
       this.$selects = $(this.options.selectTriggerClass);
       this.$multisingleSelects = $(this.options.multisingleTriggerClass);
       this.$multipleSelects = $(this.options.multipleSelectTriggerClass);
-      this.$datepickerInput = $(this.options.datepickerTriggerClass);
+      this.$datepickerInput = $(this.options.datepickerTriggerClass + ':not([data-form-processed])');
+    },
+
+    _cleanSelect2: function () {
+      $('.select2-container').remove();
+      $('.select2-hidden-accessible').removeClass('select2-hidden-accessible');
     },
 
     _loadSelect: function () {
@@ -56,6 +62,7 @@
       this.$datepickerInput.datepicker({
         dateFormat: "yy-mm-dd"
       });
+      this.$datepickerInput.attr('data-form-processed', true);
     }
 
   });


### PR DESCRIPTION
When the user press the browser back button, turbolinks returns the cache previous page and reload all the JS. The select2 components breaks with this behaviour.
![emissions scenario portal](https://cloud.githubusercontent.com/assets/1432880/26713803/b5004dea-476e-11e7-9aa9-0b08413d90f6.png)
