### PR TITLE
Removed notes from indicators and updated missing attribute definitions

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,31 +180,28 @@ en:
   indicators:
     category:
       name: "Category"
-      definition: "TODO"
+      definition: "Which category does it belong to? Categories are fixed in the system and the options are: Emissions, Climate and Health Impacts, Population and Economy, Energy, Electricty, Industry, Buildings, Transportation, Agriculture Land Use and Forestry, Policy, Technology, Financial"
     subcategory:
       name: "Subcategory"
-      definition: "TODO"
+      definition: "What sub-category does the indicator belong to? New sub-categories can be added"
     stackable_subcategory:
       name: "Stackable subcategory"
-      definition: "TODO"
+      definition: "Is the sub-category stackable, i.e. do all the indicators in the sub-category add up to some total value (examples are emissions by sector, energy generation by fuel, etc.). Avoid double counting, i.e. if there is an indicator for \"solar\", \"wind\" and \"biomass\" each, then there shouldn't be another indicators \"renewable\" in the same sub-category, as both of these would be added together in a stackable sub-category."
     name:
       name: "Name"
-      definition: "TODO"
+      definition: "Name of the indicator that is used in your model output"
     definition:
       name: "Description"
-      definition: "TODO"
+      definition: "Detailed description of the indicator. E.g. which sub-sectors are covered in industry or agriculture and land use. Special assumptions made for the indicator (if any)."
     unit:
       name: "Unit"
-      definition: "TODO"
+      definition: "Standardized unit of the ESP for this indicator"
     unit_of_entry:
       name: "Unit of entry"
-      definition: "TODO"
+      definition: "The unit in which values for this indicator are entered"
     conversion_factor:
       name: "Conversion factor"
-      definition: "TODO"
-    notes:
-      name: "Notes"
-      definition: "TODO"
+      definition: "Conversion factor between the unit of entry and the standardized unit ( = (standardized unit)/(unit of entry)), if the conversion can be expressed as a constant factor. If the conversion cannot be expressed with a constant factor consider adding a new indicator to the system."
   scenarios:
     model_abbreviation:
       name: "Model Abbreviation"

--- a/db/indicators_metadata.yml
+++ b/db/indicators_metadata.yml
@@ -18,5 +18,3 @@
   size: 'small'
 - name: :definition
   size: 'large'
-- name: :notes
-  size: 'large'

--- a/db/migrate/20170605090043_remove_notes_from_indicators.rb
+++ b/db/migrate/20170605090043_remove_notes_from_indicators.rb
@@ -1,0 +1,5 @@
+class RemoveNotesFromIndicators < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :indicators, :notes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170531094603) do
+ActiveRecord::Schema.define(version: 20170605090043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 20170531094603) do
     t.text     "name",                                  null: false
     t.text     "definition"
     t.text     "unit"
-    t.text     "notes"
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
     t.integer  "model_id"


### PR DESCRIPTION
Removes unused attribute `notes` from indicators and populates missing definitions / input tooltips.