### PR TITLE
Display indicator alias in indicator list

### DIFF
--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -4,7 +4,7 @@ class Indicator < ApplicationRecord
   ).freeze
   include MetadataAttributes
 
-  ORDERS = %w[name category subcategory definition unit].freeze
+  ORDERS = %w[alias name category subcategory definition unit].freeze
 
   belongs_to :parent, class_name: 'Indicator', optional: true
   has_many :time_series_values, dependent: :destroy

--- a/app/views/indicators/index.html.erb
+++ b/app/views/indicators/index.html.erb
@@ -60,9 +60,9 @@
     <div class="row">
       <div class="small-2 columns">
         <%= render 'shared/components/c_order_filter_button',
-                   text: 'Indicator',
+                   text: 'Slug',
                    other_class: '-no-wrap',
-                   column_key: 'name' %>
+                   column_key: 'alias' %>
       </div>
       <div class="small-2 columns">
         <%= render 'shared/components/c_order_filter_button',
@@ -77,11 +77,17 @@
       </div>
       <div class="small-1 columns">
         <%= render 'shared/components/c_order_filter_button',
+                   text: 'Name',
+                   other_class: '-no-wrap',
+                   column_key: 'name' %>
+      </div>
+      <div class="small-1 columns">
+        <%= render 'shared/components/c_order_filter_button',
                    text: 'Unit',
                    other_class: '-no-wrap',
                    column_key: 'unit' %>
       </div>
-      <div class="small-4 columns">
+      <div class="small-3 columns">
         <%= render 'shared/components/c_order_filter_button',
                    text: 'Description',
                    other_class: '-no-wrap',
@@ -93,7 +99,7 @@
     <div class="c-table-list-item">
       <div class="row">
         <div class="small-2 columns">
-          <div class="c-table-list-item__text f-ff1-m-bold"><%= link_to indicator.name, model_indicator_url(@model, indicator) %></div>
+          <div class="c-table-list-item__text f-ff1-m-bold"><%= link_to indicator.alias, model_indicator_url(@model, indicator) %></div>
         </div>
         <div class="small-2 columns">
           <div class="c-table-list-item__text f-ff1-m"><%= indicator.category %></div>
@@ -102,9 +108,12 @@
           <div class="c-table-list-item__text f-ff1-m"><%= indicator.subcategory %></div>
         </div>
         <div class="small-1 columns">
+          <div class="c-table-list-item__text f-ff1-m"><%= indicator.name %></div>
+        </div>
+        <div class="small-1 columns">
           <div class="c-table-list-item__text f-ff1-m"><%= indicator.unit %></div>
         </div>
-        <div class="small-4 columns">
+        <div class="small-3 columns">
           <div class="c-table-list-item__text f-ff1-m">
             <%= indicator.definition && truncate(indicator.definition, length: 120) %>
           </div>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -72,11 +72,11 @@
       </div>
       <div class="small-12 columns">
         <div class="l-scenarios-overview__table-shorts row js-table-filter" data-filter-type="order">
-          <div class="small-2 columns">
+          <div class="small-3 columns">
             <%= render 'shared/components/c_order_filter_button',
               text: 'Indicator',
               other_class: '-no-wrap',
-              column_key: 'name' %>
+              column_key: 'alias' %>
           </div>
           <div class="small-2 columns">
             <%= render 'shared/components/c_order_filter_button',
@@ -84,7 +84,7 @@
               other_class: '-no-wrap',
               column_key: 'unit' %>
           </div>
-          <div class="small-5 columns">
+          <div class="small-4 columns">
             <%= render 'shared/components/c_order_filter_button',
               text: 'Description',
               other_class: '-no-wrap',
@@ -102,13 +102,13 @@
     <% @indicators.each do |indicator| %>
       <div class="c-table-list-item">
         <div class="row">
-          <div class="small-2 columns">
-            <div class="c-table-list-item__text f-ff1-m-bold"><%= link_to indicator.name, model_indicator_url(@model, indicator) %></div>
+          <div class="small-3 columns">
+            <div class="c-table-list-item__text f-ff1-m-bold"><%= link_to indicator.alias, model_indicator_url(@model, indicator) %></div>
           </div>
           <div class="small-2 columns">
             <div class="c-table-list-item__text f-ff1-m"><%= indicator.unit %></div>
           </div>
-          <div class="small-5 columns">
+          <div class="small-4 columns">
             <div class="c-table-list-item__text f-ff1-m">
               <%= indicator.definition && truncate(indicator.definition, length: 150) %>
             </div>

--- a/app/views/shared/components/_c_model_overview_card.html.erb
+++ b/app/views/shared/components/_c_model_overview_card.html.erb
@@ -21,6 +21,8 @@
         <%
           if item.is_a?(Model)
             name = item.abbreviation
+          elsif item.is_a?(Indicator)
+            name = item.alias
           else
             name = item.name
           end


### PR DESCRIPTION
Show the indicators slug (column is called alias in the db) in the following lists:
- indicators index
- scenario show
- model summary

The purpose is to allow users to make a connection between the indicators in the system and in the csv upload / download files.