### PR TITLE
Filter indicators by model

### DIFF
--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -7,7 +7,12 @@ class IndicatorsController < ApplicationController
   before_action :set_filter_params, only: [:index]
 
   def index
-    @indicators = Indicator.fetch_all(@filter_params)
+    @indicators =
+      if current_user.admin?
+        Indicator.fetch_all(@filter_params)
+      else
+        Indicator.for_model(@model).fetch_all(@filter_params)
+      end
     @categories = Indicator.except(:order).
       order(:category).
       distinct.pluck(:category)

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -31,6 +31,18 @@ class Indicator < ApplicationRecord
   end
 
   class << self
+    def for_model(model)
+      model_indicators = Indicator.select(:id, :parent_id).
+        where(model_id: model.id)
+      Indicator.
+        joins("LEFT JOIN (#{model_indicators.to_sql}) model_indicators \
+ON indicators.id = model_indicators.parent_id").
+        where(
+          'model_id = ? OR model_id IS NULL AND model_indicators.id IS NULL',
+          model.id
+        )
+    end
+
     def fetch_all(options)
       indicators = Indicator
       options.each_with_index do |filter|

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -69,4 +69,24 @@ RSpec.describe Indicator, type: :model do
       expect(indicator.time_series_data?).to be(true)
     end
   end
+
+  describe :for_model do
+    let(:model1) { FactoryGirl.create(:model) }
+    let(:model2) { FactoryGirl.create(:model) }
+    let!(:core_indicator1) { FactoryGirl.create(:indicator) }
+    let!(:core_indicator2) { FactoryGirl.create(:indicator) }
+    let!(:model_indicator) {
+      FactoryGirl.create(:indicator, parent: core_indicator1, model: model1)
+    }
+    it 'returns only core indicators for model without model indicators' do
+      expect(Indicator.for_model(model2)).to match_array(
+        [core_indicator1, core_indicator2]
+      )
+    end
+    it 'returns core and model indicators for model with model indicators' do
+      expect(Indicator.for_model(model1)).to match_array(
+        [model_indicator, core_indicator2]
+      )
+    end
+  end
 end


### PR DESCRIPTION
When logged in as researcher, show model indicators or core indicators without a model variant.