### PR TITLE
Fix/upload file with invalid encoding and too many errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'devise'
 gem 'devise_invitable'
 gem 'sendgrid-ruby'
 gem 'pg_csv'
+gem 'charlock_holmes'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
     builder (3.2.3)
     byebug (9.0.6)
     cancancan (1.17.0)
+    charlock_holmes (0.7.3)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -262,6 +263,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   cancancan (~> 1.10)
+  charlock_holmes
   coffee-rails (~> 4.2)
   devise
   devise_invitable

--- a/lib/modules/csv_upload_data.rb
+++ b/lib/modules/csv_upload_data.rb
@@ -1,3 +1,4 @@
+require 'charlock_holmes'
 module CsvUploadData
   def initialize_stats
     @number_of_rows = File.foreach(@path).count - 1
@@ -11,7 +12,10 @@ module CsvUploadData
 
   def process
     return if @headers.errors.any?
-    CSV.open(@path, 'r', headers: true).each.with_index(2) do |row, row_no|
+    detection = CharlockHolmes::EncodingDetector.detect(File.read(@path))
+    CSV.open(
+      @path, 'r', headers: true, encoding: detection[:encoding]
+    ).each.with_index(2) do |row, row_no|
       process_row(row, row_no)
     end
   end


### PR DESCRIPTION
In relation to: https://basecamp.com/1756858/projects/12901811/messages/69831648

2 problems in single file:
- invalid encoding. Fixed by applying encoding detection prior to opening the file.
- too many errors to return using flash (on redirect). Fixed by suppressing excessive output.