### PR TITLE
Incorporate error resolution suggestions in error messages

### DIFF
--- a/lib/modules/csv_upload_data.rb
+++ b/lib/modules/csv_upload_data.rb
@@ -68,4 +68,11 @@ missing data into the system first."
   def format_error(message, suggestion)
     [message, suggestion].join(' ')
   end
+
+  def process_other_errors(row_errors, object_errors)
+    object_errors.each do |key, value|
+      next if row_errors.key?(key.to_s)
+      row_errors[key] = "#{key.capitalize} #{value}."
+    end
+  end
 end

--- a/lib/modules/csv_upload_data.rb
+++ b/lib/modules/csv_upload_data.rb
@@ -1,4 +1,6 @@
 require 'charlock_holmes'
+require 'file_upload_error'
+
 module CsvUploadData
   def initialize_stats
     @number_of_rows = File.foreach(@path).count - 1
@@ -66,7 +68,7 @@ missing data into the system first."
   end
 
   def format_error(message, suggestion)
-    [message, suggestion].join(' ')
+    FileUploadError.new(message, suggestion, 'TODO', 'TODO')
   end
 
   def process_other_errors(row_errors, object_errors)

--- a/lib/modules/csv_upload_headers.rb
+++ b/lib/modules/csv_upload_headers.rb
@@ -32,7 +32,7 @@ module CsvUploadHeaders
           expected_index: expected_index
         }
       else
-        @errors[header] = 'Unrecognised header'
+        @errors[header] = 'Unrecognised header. Please consult the template.'
         {
           display_name: header
         }

--- a/lib/modules/csv_upload_headers.rb
+++ b/lib/modules/csv_upload_headers.rb
@@ -1,4 +1,5 @@
 require 'csv'
+require 'file_upload_error'
 
 module CsvUploadHeaders
   def initialize_headers(path)
@@ -32,7 +33,12 @@ module CsvUploadHeaders
           expected_index: expected_index
         }
       else
-        @errors[header] = 'Unrecognised header. Please consult the template.'
+        message = 'Unrecognised column header.'
+        suggestion = 'Please consult the template for correct structure.'
+        # TODO url
+        @errors[header] = FileUploadError.new(
+          message, suggestion, 'TODO', 'TODO'
+        )
         {
           display_name: header
         }

--- a/lib/modules/csv_upload_headers.rb
+++ b/lib/modules/csv_upload_headers.rb
@@ -2,6 +2,8 @@ require 'csv'
 require 'file_upload_error'
 
 module CsvUploadHeaders
+  delegate :url_helpers, to: 'Rails.application.routes'
+
   def initialize_headers(path)
     @headers = CSV.open(path, 'r') do |csv|
       headers = csv.first
@@ -15,7 +17,7 @@ module CsvUploadHeaders
     end.map(&:downcase)
   end
 
-  def parse_headers
+  def parse_headers(template_url)
     expected_headers = self.class::EXPECTED_HEADERS.
       map do |eh|
         eh[:display_name].
@@ -34,10 +36,9 @@ module CsvUploadHeaders
         }
       else
         message = 'Unrecognised column header.'
-        suggestion = 'Please consult the template for correct structure.'
-        # TODO url
+        suggestion = 'Please consult the [template] for correct structure.'
         @errors[header] = FileUploadError.new(
-          message, suggestion, 'TODO', 'TODO'
+          message, suggestion, url: template_url, placeholder: 'template'
         )
         {
           display_name: header

--- a/lib/modules/file_upload_error.rb
+++ b/lib/modules/file_upload_error.rb
@@ -1,0 +1,9 @@
+FileUploadError = Struct.new(:message, :suggestion, :link, :link_placeholder) do
+  def suggestion_with_link
+    suggestion.sub(link_placeholder, link)
+  end
+
+  def to_s
+    [message, suggestion_with_link].join(' ')
+  end
+end

--- a/lib/modules/file_upload_error.rb
+++ b/lib/modules/file_upload_error.rb
@@ -1,6 +1,11 @@
-FileUploadError = Struct.new(:message, :suggestion, :link, :link_placeholder) do
+FileUploadError = Struct.new(
+  :message, :suggestion, :link_options
+) do
   def suggestion_with_link
-    suggestion.sub(link_placeholder, link)
+    suggestion.sub(
+      /\[#{link_options[:placeholder]}\]/,
+      "<a href=\"#{link_options[:url]}\">#{link_options[:placeholder]}</a>"
+    )
   end
 
   def to_s

--- a/lib/modules/file_upload_error.rb
+++ b/lib/modules/file_upload_error.rb
@@ -4,7 +4,7 @@ FileUploadError = Struct.new(
   def suggestion_with_link
     suggestion.sub(
       /\[#{link_options[:placeholder]}\]/,
-      "<a href=\"#{link_options[:url]}\">#{link_options[:placeholder]}</a>"
+      "<a href=\"\"#{link_options[:url]}\"\">#{link_options[:placeholder]}</a>"
     )
   end
 

--- a/lib/modules/file_upload_status.rb
+++ b/lib/modules/file_upload_status.rb
@@ -20,14 +20,14 @@ class FileUploadStatus
 
   def errors_to_array
     rows = []
-    errors.except(:type).each do |key, message_hash_or_string|
+    errors.except(:type).each do |key, message_hash_or_struct|
       rows_to_append =
-        if message_hash_or_string.is_a?(Hash)
-          message_hash_or_string.values.map do |message|
+        if message_hash_or_struct.is_a?(Hash)
+          message_hash_or_struct.values.map do |message|
             "#{key},\"#{message}\""
           end
         else
-          ["#{key},\"#{message_hash_or_string}\""]
+          ["#{key},\"#{message_hash_or_struct}\""]
         end
       rows += rows_to_append
     end

--- a/lib/modules/file_upload_status.rb
+++ b/lib/modules/file_upload_status.rb
@@ -24,9 +24,6 @@ class FileUploadStatus
       rows_to_append =
         if message_hash_or_string.is_a?(Hash)
           message_hash_or_string.values.map do |message|
-            if message.is_a?(ActiveModel::Errors)
-              message = message.map { |k, v| "#{k}: #{v}" }.join(', ')
-            end
             "#{key},\"#{message}\""
           end
         else

--- a/lib/modules/indicators_data.rb
+++ b/lib/modules/indicators_data.rb
@@ -116,12 +116,13 @@ indicator instead.'
   def create_or_update_indicator(indicator, attributes, row_no)
     if indicator.nil?
       indicator = Indicator.new(attributes)
-      # TODO: parse
-      @errors[row_no]['indicator'] = indicator.errors unless indicator.save
+      return indicator if indicator.save
+      process_other_errors(@errors[row_no], indicator.errors)
     else
       unless indicator.update_attributes(attributes)
-        # TODO: parse
-        @errors[row_no]['indicator'] = indicator.errors
+        process_other_errors(
+          @errors[row_no], indicator.errors
+        )
       end
     end
   end

--- a/lib/modules/indicators_data.rb
+++ b/lib/modules/indicators_data.rb
@@ -21,8 +21,10 @@ class IndicatorsData
     elsif slug.present?
       process_core_indicator(slug, row, row_no)
     else
-      @errors[row_no]['slug'] = 'At least one of ESP Indicator Name and Model /
-Indicator Name required'
+      message = 'At least one of ESP Indicator Name and Model Indicator Name \
+must be present.'
+      suggestion = 'Please fill in missing data.'
+      @errors[row_no]['slug'] = format_error(message, suggestion)
     end
     if @errors[row_no].any?
       @number_of_rows_failed += 1
@@ -33,7 +35,10 @@ Indicator Name required'
 
   def process_core_indicator(slug, row, row_no)
     if @user.cannot?(:manage, Model)
-      errors['model'] = 'Access denied: managing core indicators'
+      message = 'Access denied to manage core indicators.'
+      suggestion = 'ESP admins curate core indicators. Please add a model \
+indicator instead.'
+      errors['model'] = format_error(message, suggestion)
       return nil
     end
     id_attributes = Indicator.slug_to_hash(slug)
@@ -52,7 +57,11 @@ Indicator Name required'
 
   def process_indicator_variation(slug, model_slug, row, row_no)
     if @user.cannot?(:manage, @model)
-      errors['model'] = 'Access denied: managing model indicators'
+      message = "Access denied to manage model indicators \
+(#{model.abbreviation})."
+      suggestion = 'Please verify your team\'s permissions.'
+      # TODO: url
+      errors['model'] = format_error(message, suggestion)
       return nil
     end
     unless slug.present?
@@ -107,9 +116,11 @@ Indicator Name required'
   def create_or_update_indicator(indicator, attributes, row_no)
     if indicator.nil?
       indicator = Indicator.new(attributes)
+      # TODO: parse
       @errors[row_no]['indicator'] = indicator.errors unless indicator.save
     else
       unless indicator.update_attributes(attributes)
+        # TODO: parse
         @errors[row_no]['indicator'] = indicator.errors
       end
     end

--- a/lib/modules/indicators_data.rb
+++ b/lib/modules/indicators_data.rb
@@ -59,9 +59,13 @@ indicator instead.'
     if @user.cannot?(:manage, @model)
       message = "Access denied to manage model indicators \
 (#{model.abbreviation})."
-      suggestion = 'Please verify your team\'s permissions.'
-      # TODO: url
-      errors['model'] = format_error(message, suggestion)
+      suggestion = 'Please verify your team\'s permissions [here].'
+      errors['model'] = format_error(
+        message,
+        suggestion,
+        url: url_helpers.model_url(@model),
+        placeholder: 'here'
+      )
       return nil
     end
     unless slug.present?
@@ -73,7 +77,8 @@ indicator instead.'
       Indicator.where(id_attributes).where('parent_id IS NULL'),
       'indicator',
       "indicator: #{slug}",
-      @errors[row_no]
+      @errors[row_no],
+      url_helpers.model_indicators_path(@model)
     )
     return unless indicator
 

--- a/lib/modules/indicators_headers.rb
+++ b/lib/modules/indicators_headers.rb
@@ -46,6 +46,6 @@ class IndicatorsHeaders
     initialize_headers(path)
     @model = model
     @errors = {}
-    parse_headers
+    parse_headers('/esp_indicators_template.csv')
   end
 end

--- a/lib/modules/scenarios_data.rb
+++ b/lib/modules/scenarios_data.rb
@@ -31,6 +31,7 @@ class ScenariosData
 
     scenario ||= Scenario.new
     scenario.attributes = scenario_attributes
+    # TODO: parse
     @errors[row_no]['scenario'] = scenario.errors unless scenario.save
 
     if @errors[row_no].any?
@@ -46,23 +47,5 @@ class ScenariosData
       value = value.split(';').map(&:strip) unless value.blank?
     end
     value
-  end
-
-  def model(row, errors)
-    model_abbreviation = value_for(row, :model_abbreviation)
-    if model_abbreviation.blank?
-      errors['model'] = 'Model must be present'
-      return nil
-    end
-    identification = "model: #{model_abbreviation}"
-
-    models = Model.where(abbreviation: model_abbreviation)
-    model = matching_object(models, 'model', identification, errors)
-    return nil if model.nil?
-    if @user.cannot?(:manage, model)
-      errors['model'] = "Access denied: model (#{identification})"
-      return nil
-    end
-    model
   end
 end

--- a/lib/modules/scenarios_data.rb
+++ b/lib/modules/scenarios_data.rb
@@ -24,6 +24,11 @@ class ScenariosData
         end
       ]
     )
+    if scenario_attributes[:name].blank?
+      message = 'Scenario name must be present.'
+      suggestion = 'Please fill in missing data.'
+      @errors[row_no]['name'] = format_error(message, suggestion)
+    end
 
     scenario = model && Scenario.where(
       model_id: model.id, name: scenario_attributes[:name]
@@ -31,8 +36,7 @@ class ScenariosData
 
     scenario ||= Scenario.new
     scenario.attributes = scenario_attributes
-    # TODO: parse
-    @errors[row_no]['scenario'] = scenario.errors unless scenario.save
+    process_other_errors(@errors[row_no], scenario.errors) unless scenario.save
 
     if @errors[row_no].any?
       @number_of_rows_failed += 1

--- a/lib/modules/scenarios_headers.rb
+++ b/lib/modules/scenarios_headers.rb
@@ -56,10 +56,10 @@ class ScenariosHeaders
   def initialize(path)
     initialize_headers(path)
     @errors = {}
-    parse_headers
+    parse_headers('/esp_scenarios_template.csv')
   end
 
-  def parse_headers
+  def parse_headers(template_url)
     expected_headers = EXPECTED_HEADERS.
       map { |eh| eh[:display_name].downcase.gsub(/[^a-z0-9]/i, '') }
     @actual_headers = @headers.
@@ -73,10 +73,9 @@ class ScenariosHeaders
         }
       else
         message = 'Unrecognised column header.'
-        suggestion = 'Please consult the template for correct structure.'
-        # TODO url
+        suggestion = 'Please consult the [template] for correct structure.'
         @errors[header] = FileUploadError.new(
-          message, suggestion, 'TODO', 'TODO'
+          message, suggestion, url: template_url, placeholder: 'template'
         )
         {
           display_name: header

--- a/lib/modules/scenarios_headers.rb
+++ b/lib/modules/scenarios_headers.rb
@@ -72,7 +72,12 @@ class ScenariosHeaders
           expected_index: expected_index
         }
       else
-        @errors[header] = 'Unrecognised header'
+        message = 'Unrecognised column header.'
+        suggestion = 'Please consult the template for correct structure.'
+        # TODO url
+        @errors[header] = FileUploadError.new(
+          message, suggestion, 'TODO', 'TODO'
+        )
         {
           display_name: header
         }

--- a/lib/modules/time_series_values_data.rb
+++ b/lib/modules/time_series_values_data.rb
@@ -15,6 +15,7 @@ class TimeSeriesValuesData
     @errors[row_no] = {}
 
     values_by_year(row, @errors[row_no]).each do |tsv|
+      # TODO: parse
       @errors[row_no][tsv.year] = tsv.errors unless tsv.save
     end
 
@@ -69,24 +70,6 @@ class TimeSeriesValuesData
     end
   end
 
-  def model(row, errors)
-    model_abbreviation = value_for(row, :model_abbreviation)
-    if model_abbreviation.blank?
-      errors['model'] = 'Model must be present'
-      return nil
-    end
-    identification = "model: #{model_abbreviation}"
-
-    models = Model.where(abbreviation: model_abbreviation)
-    model = matching_object(models, 'model', identification, errors)
-    return nil if model.nil?
-    if @user.cannot?(:manage, model)
-      errors['model'] = "Access denied: model (#{identification})"
-      return nil
-    end
-    model
-  end
-
   def scenario(model, row, errors)
     return nil if model.nil?
     scenario_name = value_for(row, :scenario_name)
@@ -121,8 +104,12 @@ class TimeSeriesValuesData
     return nil if unit_of_entry.nil?
     if unit_of_entry != indicator.unit &&
         unit_of_entry != indicator.unit_of_entry
-      errors['unit_of_entry'] = "Conversion factor unavailable for unit of \
-entry #{unit_of_entry}"
+      message = "Conversion factor unavailable for unit of entry \
+#{unit_of_entry}."
+      suggestion = 'Please ensure unit of entry is compatible with indicator \
+standardized unit'
+      # TODO: url
+      errors['unit_of_entry'] = format_error(message, suggestion)
     end
     unit_of_entry
   end

--- a/lib/modules/time_series_values_data.rb
+++ b/lib/modules/time_series_values_data.rb
@@ -15,8 +15,8 @@ class TimeSeriesValuesData
     @errors[row_no] = {}
 
     values_by_year(row, @errors[row_no]).each do |tsv|
-      # TODO: parse
-      @errors[row_no][tsv.year] = tsv.errors unless tsv.save
+      next if tsv.save
+      process_other_errors(@errors[row_no], tsv.errors, tsv.year)
     end
 
     if @errors[row_no].any?
@@ -41,7 +41,7 @@ class TimeSeriesValuesData
     year_values = @headers.year_headers.map do |h|
       year = h[:display_name].to_i
       value = row[@headers.actual_index_of_year(h[:display_name])]
-      value.blank? ? nil : [year, value.to_f]
+      value.blank? ? nil : [year, value]
     end.compact
 
     year_values.map do |year, value|
@@ -124,5 +124,14 @@ standardized unit'
       errors['unit_of_entry'] = format_error(message, suggestion)
     end
     unit_of_entry
+  end
+
+  def process_other_errors(row_errors, object_errors, year)
+    object_errors.each do |key, value|
+      next if row_errors.key?(key.to_s)
+      message = "Year #{year}: #{key.capitalize} #{value}."
+      suggestion = ''
+      row_errors[year] = format_error(message, suggestion)
+    end
   end
 end

--- a/lib/modules/time_series_values_data.rb
+++ b/lib/modules/time_series_values_data.rb
@@ -73,6 +73,12 @@ class TimeSeriesValuesData
   def scenario(model, row, errors)
     return nil if model.nil?
     scenario_name = value_for(row, :scenario_name)
+    if scenario_name.blank?
+      message = 'Scenario must be present.'
+      suggestion = 'Please fill in the scenario name.'
+      errors['scenario'] = format_error(message, suggestion)
+      return nil
+    end
     identification = "model: #{model.abbreviation}, scenario: \
 #{scenario_name}"
 
@@ -83,6 +89,12 @@ class TimeSeriesValuesData
   def indicator(model, row, errors)
     return nil if model.nil?
     indicator_name = value_for(row, :indicator_name)
+    if indicator_name.blank?
+      message = 'Indicator must be present.'
+      suggestion = 'Please fill in the ESP indicator name.'
+      errors['indicator'] = format_error(message, suggestion)
+      return nil
+    end
     identification = "indicator: #{indicator_name}"
 
     indicators = Indicator.where(alias: indicator_name)

--- a/lib/modules/time_series_values_headers.rb
+++ b/lib/modules/time_series_values_headers.rb
@@ -37,10 +37,10 @@ class TimeSeriesValuesHeaders
   def initialize(path)
     initialize_headers(path)
     @errors = {}
-    parse_headers
+    parse_headers('/esp_time_series_template.csv')
   end
 
-  def parse_headers
+  def parse_headers(template_url)
     expected_headers = EXPECTED_HEADERS.
       map { |eh| eh[:display_name].downcase.gsub(/[^a-z0-9]/i, '') }
     @actual_headers = @headers.
@@ -59,10 +59,9 @@ class TimeSeriesValuesHeaders
         }
       else
         message = 'Unrecognised column header.'
-        suggestion = 'Please consult the template for correct structure.'
-        # TODO url
+        suggestion = 'Please consult the [template] for correct structure.'
         @errors[header] = FileUploadError.new(
-          message, suggestion, 'TODO', 'TODO'
+          message, suggestion, url: template_url, placeholder: 'template'
         )
         {
           display_name: header

--- a/lib/modules/time_series_values_headers.rb
+++ b/lib/modules/time_series_values_headers.rb
@@ -58,7 +58,12 @@ class TimeSeriesValuesHeaders
           year_header: true
         }
       else
-        @errors[header] = 'Unrecognised header'
+        message = 'Unrecognised column header.'
+        suggestion = 'Please consult the template for correct structure.'
+        # TODO url
+        @errors[header] = FileUploadError.new(
+          message, suggestion, 'TODO', 'TODO'
+        )
         {
           display_name: header
         }


### PR DESCRIPTION
This work prepares for the changes in presentation of upload errors. For now they are still presented in a CSV file, but have more structure and additional details:
- suggestions for error resolution, kept separate from the error message itself
- in some cases, link to the page where error can be resolved incorporated into the suggestion