### PR TITLE
Fix/title of models index page

### DIFF
--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -3,9 +3,7 @@ class ModelsController < ApplicationController
 
   before_action :set_nav_links, only: [:index, :show, :edit]
 
-  def index
-    redirect_to model_url(@models.first) and return if @models.length == 1
-  end
+  def index; end
 
   def new
     @model = Model.new

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -9,7 +9,13 @@
   </div>
   <div class="row">
     <div class="small-12 columns">
-      <div class="l-models__title f-ff3-m-bold">Select the model you want to manage</div>
+      <div class="l-models__title f-ff3-m-bold">
+        <% if current_user.admin? %>
+          Manage all models in the system
+        <% else %>
+          Manage your team's models
+        <% end %>
+      </div>
     </div>
   </div>
   <div class="row">

--- a/spec/controllers/models_controller_spec.rb
+++ b/spec/controllers/models_controller_spec.rb
@@ -60,15 +60,9 @@ RSpec.describe ModelsController, type: :controller do
         expect(assigns[:models].count).to eq(1)
       end
 
-      it 'renders index when more than one model available' do
-        FactoryGirl.create(:model, team: @user.team)
+      it 'renders index' do
         get :index
         expect(response).to render_template(:index)
-      end
-
-      it 'redirects to model when only one model available' do
-        get :index
-        expect(response).to redirect_to(model_url(team_model))
       end
     end
 


### PR DESCRIPTION
Changes title of the models page to make it less confusing why an admin / researcher is seeing all / some of the models. Also removes the redirect to model overview when only 1 model available.

https://www.pivotaltracker.com/story/show/147435611