### PR TITLE
Fix/remove todos

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,8 +11,6 @@ module ApplicationHelper
     attr_info = object.class.attribute_info(attr_symbol)
     if attr_info.reference?
       reference_input(object, form, attr_info)
-    elsif attr_info.date?
-      date_input(object, form, attr_info)
     elsif attr_info.picklist?
       picklist_input(object, form, attr_info)
     elsif attr_info.checkbox?
@@ -28,12 +26,6 @@ module ApplicationHelper
       attr_info.name,
       class: "c-input-text -#{size} js-form-input"
     )
-  end
-
-  def date_input(_object, form, attr_info)
-    size = attr_info.size
-    form.text_field attr_info.name, class:
-      "c-input-text -#{size} js-datepicker-input js-form-input"
   end
 
   def picklist_input(object, form, attr_info)

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -9,7 +9,6 @@ class Scenario < ApplicationRecord
 
   validates :name, presence: true
   validates :model, presence: true
-  # TODO: validate release date is a date
   before_validation :ignore_blank_array_values
 
   delegate :abbreviation, to: :model, prefix: :model

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -23,10 +23,6 @@
         <div class="f-ff1-m-bold">Last edit</div>
         <div class="f-ff1-m l-scenarios-overview__data"><%= @scenario.updated_at.strftime("%b %d %Y") %></div>
       </div>
-      <div class="small-2 columns">
-        <div class="f-ff1-m-bold">Published</div>
-        <div class="f-ff1-m l-scenarios-overview__data">TODO</div>
-      </div>
       <div class="small-1 columns">
         <%= link_to edit_model_scenario_url(@model, @scenario) do %>
           <div class="c-edit-button">
@@ -72,7 +68,7 @@
       </div>
       <div class="small-12 columns">
         <div class="l-scenarios-overview__table-shorts row js-table-filter" data-filter-type="order">
-          <div class="small-3 columns">
+          <div class="small-5 columns">
             <%= render 'shared/components/c_order_filter_button',
               text: 'Indicator',
               other_class: '-no-wrap',
@@ -90,10 +86,6 @@
               other_class: '-no-wrap',
               column_key: 'definition' %>
           </div>
-          <div class="small-2 columns">
-            <%= render 'shared/components/c_order_filter_button',
-              text: 'Added by' %>
-          </div>
         </div>
       </div>
     </div>
@@ -102,7 +94,7 @@
     <% @indicators.each do |indicator| %>
       <div class="c-table-list-item">
         <div class="row">
-          <div class="small-3 columns">
+          <div class="small-5 columns">
             <div class="c-table-list-item__text f-ff1-m-bold"><%= link_to indicator.alias, model_indicator_url(@model, indicator) %></div>
           </div>
           <div class="small-2 columns">
@@ -112,9 +104,6 @@
             <div class="c-table-list-item__text f-ff1-m">
               <%= indicator.definition && truncate(indicator.definition, length: 150) %>
             </div>
-          </div>
-          <div class="small-2 columns">
-            <div class="c-table-list-item__text f-ff1-m">TODO</div>
           </div>
           <div class="small-1 columns">
             <div class="c-table-list-item__actions">

--- a/db/migrate/20170703083250_change_release_date_to_text.rb
+++ b/db/migrate/20170703083250_change_release_date_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeReleaseDateToText < ActiveRecord::Migration[5.0]
+  def change
+    change_column :scenarios, :release_date, :text
+  end
+end

--- a/db/scenarios_metadata.yml
+++ b/db/scenarios_metadata.yml
@@ -9,7 +9,6 @@
   size: 'large'
   category: 'Model and provider'
 - name: :release_date
-  date: true
   size: 'small'
   category: 'Model and provider'
 - name: :name

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170626094831) do
+ActiveRecord::Schema.define(version: 20170703083250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,7 +104,7 @@ ActiveRecord::Schema.define(version: 20170626094831) do
     t.text     "model_abbreviation"
     t.text     "model_version"
     t.text     "provider_name"
-    t.date     "release_date"
+    t.text     "release_date"
     t.text     "category"
     t.text     "description"
     t.text     "geographic_coverage_region",       default: [],              array: true

--- a/lib/modules/metadata_attributes.rb
+++ b/lib/modules/metadata_attributes.rb
@@ -33,10 +33,6 @@ module MetadataAttributes
       @multiple.present?
     end
 
-    def date?
-      @input_type == :date
-    end
-
     def checkbox?
       @input_type == :checkbox
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:form) {
         ActionView::Helpers::FormBuilder.new(:scenario, scenario, self, {})
       }
-      it 'returns a date input field for release_date' do
+      it 'returns a text input field for release_date' do
         expect(
           helper.attribute_input(scenario, form, :release_date)
-        ).to match('js-datepicker-input')
+        ).to match('js-form-input')
       end
       it 'returns a select input for model_abbreviation' do
         expect(

--- a/spec/models/metadata_attributes_info_spec.rb
+++ b/spec/models/metadata_attributes_info_spec.rb
@@ -16,21 +16,6 @@ RSpec.describe MetadataAttributes::Info, type: :model do
     end
   end
 
-  describe :date? do
-    let(:date_attribute_info) {
-      Scenario.attribute_info(:release_date)
-    }
-    let(:not_date_attribute_info) {
-      Scenario.attribute_info(:description)
-    }
-    it 'should be true when attribute is a date' do
-      expect(date_attribute_info.date?).to be(true)
-    end
-    it 'should be false when attribute is not a date' do
-      expect(not_date_attribute_info.date?).to be(false)
-    end
-  end
-
   describe :picklist? do
     let(:picklist_attribute_info) {
       Model.attribute_info(:expertise)

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe Model, type: :model do
       FactoryGirl.build(:model, abbreviation: 'A-Team')
     ).to have(1).errors_on(:abbreviation)
   end
-  pending 'should be invalid when team not present (?)' do
-    expect(
-      FactoryGirl.build(:model, team: nil)
-    ).to have(1).errors_on(:team)
-  end
   it 'should be invalid when trying to reassign team' do
     model = FactoryGirl.create(:model)
     another_team = FactoryGirl.create(:team)


### PR DESCRIPTION
Removes some remaining TODOs in code:
- pending spec that no longer applies
- "added by" elements of the interface (user stamping not implemented)
- changed release_date in scenarios from date type to text (according to new metadata templates), which allowed to remove a TODO as well as some date-attribute related codes (this was the only one)