### PR TITLE
Feature/both names filled in to create team indicator

### DIFF
--- a/app/helpers/indicators_helper.rb
+++ b/app/helpers/indicators_helper.rb
@@ -25,7 +25,9 @@ module IndicatorsHelper
 
   def values_for_indicator_parent_dropdown(indicator)
     selection = indicator.parent
-    select_values = Indicator.where('parent_id IS NULL').select(:id, :alias).
+    select_values = Indicator.where('parent_id IS NULL').
+      where('model_id IS NULL OR model_id != ?', @model.id).
+      select(:id, :alias).
       map do |i|
         [i.alias, i.id]
       end

--- a/app/models/concerns/alias_transformations.rb
+++ b/app/models/concerns/alias_transformations.rb
@@ -4,7 +4,11 @@ module AliasTransformations
   extend ActiveSupport::Concern
 
   included do
-    before_save :update_alias, if: proc { |i| i.parent.blank? }
+    # update alias if system indicator
+    # or team indicator with blank alias
+    before_save :update_alias, if: proc { |i|
+      i.parent_id.blank? && (i.model_id.blank? || i.alias.blank?)
+    }
   end
 
   def update_alias

--- a/app/models/concerns/scope_management.rb
+++ b/app/models/concerns/scope_management.rb
@@ -5,7 +5,10 @@ module ScopeManagement
 
   included do
     before_save :promote_parent_to_system_indicator, if: proc { |i|
-      i.parent.present? && i.parent.model_id.present?
+      i.parent.present? &&
+        i.parent.parent_id.blank? &&
+        i.parent.model_id.present? &&
+        i.model_id != i.parent.model_id
     }
   end
 

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -71,9 +71,13 @@ class Indicator < ApplicationRecord
         joins("LEFT JOIN (#{team_indicators.to_sql}) team_indicators \
 ON indicators.id = team_indicators.parent_id").
         where(
-          "model_id = ? OR model_id IS NULL AND team_indicators.id IS NULL OR \
-model_id != ? AND indicators.parent_id IS NULL",
-          model.id, model.id
+          "indicators.model_id = :model_id AND \
+indicators.parent_id IS NOT NULL OR \
+indicators.model_id = :model_id AND indicators.parent_id IS NULL AND \
+team_indicators.id IS NULL OR \
+indicators.model_id IS NULL AND team_indicators.id IS NULL OR \
+indicators.model_id != :model_id AND indicators.parent_id IS NULL",
+          model_id: model.id
         )
     end
 

--- a/spec/fixtures/indicators-correct.csv
+++ b/spec/fixtures/indicators-correct.csv
@@ -1,4 +1,3 @@
 ESP Indicator Name,Model A Indicator Name,Stackable sub-category?,Standardized Unit,Unit of Entry,Conversion factor,Definition,
 Emissions|CO2 by sector|electricity,,yes,Mt CO2e/yr,Mt CO2e/yr,,"carbon dioxide emissions from the industrial sector, including feedstocks, including agriculture and fishing",
 Emissions|CO2 by sector|industry,Emissions|CO2|Fossil Fuels and Industry|Energy Demand|Industry,yes,Mt CO2e/yr,Mt CO2e/yr,,"carbon dioxide emissions from the industrial sector, including feedstocks, including agriculture and fishing",
-,Emissions|CO2|Fossil Fuels and Industry|Energy Demand|Transport,yes,Mt CO2e/yr,Mt CO2e/yr,,"carbon dioxide emissions from the industrial sector, including feedstocks, including agriculture and fishing",

--- a/spec/fixtures/indicators-two_team_indicators.csv
+++ b/spec/fixtures/indicators-two_team_indicators.csv
@@ -1,0 +1,3 @@
+ESP Indicator Name,Model A Indicator Name,Stackable sub-category?,Standardized Unit,Unit of Entry,Conversion factor,Definition,
+"Population and Economy|Population by age|<fill in age groups>","Macroeconomic Indicators|Population, aged 16 and over",yes,Millions,Millions,,"xxx"
+"Population and Economy|Population by age|<fill in age groups>","Macroeconomic Indicators|Population, aged 65 and over",yes,Millions,Millions,,"xxx"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         ).to match('checkbox')
       end
       it 'returns a select input for parent_id' do
+        assign(:model, model)
         expect(
           helper.attribute_input(indicator, form, :parent_id)
         ).to match('select')

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -87,11 +87,14 @@ RSpec.describe Indicator, type: :model do
 
   context 'forking system indicators from team indicators' do
     let(:model) { FactoryGirl.create(:model) }
+    let(:other_model) { FactoryGirl.create(:model) }
     let!(:team_indicator) { FactoryGirl.create(:indicator, model: model) }
 
     describe :promote_parent_to_system_indicator do
       subject {
-        FactoryGirl.create(:indicator, parent: team_indicator, model: model)
+        FactoryGirl.create(
+          :indicator, parent: team_indicator, model: other_model
+        )
       }
       it 'should create 2 new indicators' do
         expect { subject }.to(change { Indicator.count }.by(2))

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -200,6 +200,9 @@ RSpec.describe Indicator, type: :model do
     let!(:team_variation1) {
       FactoryGirl.create(:indicator, parent: core_indicator1, model: model1)
     }
+    let!(:team_variation2) {
+      FactoryGirl.create(:indicator, parent: team_indicator1, model: model1)
+    }
     it 'returns core and team indicators' do
       expect(Indicator.for_model(model2)).to match_array(
         [core_indicator1, core_indicator2, team_indicator1]
@@ -207,7 +210,7 @@ RSpec.describe Indicator, type: :model do
     end
     it 'returns core, team and variation indicators' do
       expect(Indicator.for_model(model1)).to match_array(
-        [team_variation1, core_indicator2, team_indicator1]
+        [team_variation1, core_indicator2, team_variation2]
       )
     end
   end


### PR DESCRIPTION
Please review & merge #94 first, I'll then resolve conflicts here

This is a change to team indicators resulting from client feedback. A team indicator can now be selected as a parent of a variation. In case of the csv upload, if user is not an admin, the name specified in the first column will be used as the team indicator's name, and the name in the second column as the variation's name.

A process whereby creating a variation of a team indicator promotes it to a system indicator automatically is still in place, but only applies to team indicators created by other teams. 