### PR TITLE
Fix/indicator name columns again

### DIFF
--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -9,12 +9,8 @@ class IndicatorsController < ApplicationController
   before_action :set_filter_params, only: [:index, :show]
 
   def index
-    @indicators =
-      if current_user.admin?
-        Indicator.for_admin.fetch_all(@filter_params)
-      else
-        Indicator.for_model(@model).fetch_all(@filter_params)
-      end
+    @indicators = Indicator.system_indicators_with_variations.
+      fetch_all(@filter_params)
   end
 
   def new

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -11,7 +11,7 @@ class IndicatorsController < ApplicationController
   def index
     @indicators =
       if current_user.admin?
-        Indicator.fetch_all(@filter_params)
+        Indicator.for_admin.fetch_all(@filter_params)
       else
         Indicator.for_model(@model).fetch_all(@filter_params)
       end

--- a/app/models/concerns/alias_transformations.rb
+++ b/app/models/concerns/alias_transformations.rb
@@ -11,8 +11,12 @@ module AliasTransformations
     }
   end
 
+  def build_alias
+    [category, subcategory, name].join('|').chomp('|')
+  end
+
   def update_alias
-    self.alias = [category, subcategory, name].join('|').chomp('|')
+    self.alias = build_alias
   end
 
   class_methods do

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -94,7 +94,7 @@ class Indicator < ApplicationRecord
       when 'type'
         fetch_by_type(indicators, value)
       when 'category'
-        fetch_equal_value(indicators, filter, value)
+        fetch_equal_value(indicators, 'indicators.category', value)
       else
         indicators
       end

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -35,6 +35,9 @@ class Indicator < ApplicationRecord
   before_validation :ignore_blank_array_values
   before_save :update_category, if: proc { |i| i.parent.present? }
 
+  scope :system_indicators_with_variations, lambda {
+    where(parent_id: nil).eager_load(:variations)
+  }
   pg_search_scope :search_for, against: [
     :category, :subcategory, :name, :alias
   ]
@@ -69,21 +72,6 @@ class Indicator < ApplicationRecord
   end
 
   class << self
-    def for_admin
-      Indicator.where(parent_id: nil).
-        eager_load(:variations)
-      # TODO: group variations
-    end
-
-    def for_model(model)
-      Indicator.
-        where(parent_id: nil).
-        where(
-          'indicators.model_id IS NULL OR indicators.model_id = ?', model.id
-        ).
-        eager_load(:variations)
-    end
-
     def fetch_all(options)
       indicators = Indicator.all
       options.each do |filter, value|

--- a/app/views/indicators/_list.html.erb
+++ b/app/views/indicators/_list.html.erb
@@ -49,13 +49,13 @@
       <%= render 'shared/components/c_order_filter_button',
                  text: 'ESP Indicator Name',
                  other_class: '-no-wrap',
-                 column_key: 'name' %>
+                 column_key: 'esp_name' %>
     </div>
     <div class="small-2 columns">
       <%= render 'shared/components/c_order_filter_button',
                  text: "#{@model.abbreviation} Indicator Name",
                  other_class: '-no-wrap',
-                 column_key: 'variation_name' %>
+                 column_key: 'model_name' %>
     </div>
     <div class="small-2 columns">
       <%= render 'shared/components/c_order_filter_button',

--- a/app/views/indicators/_list.html.erb
+++ b/app/views/indicators/_list.html.erb
@@ -47,15 +47,15 @@
   <div class="row">
     <div class="small-3 columns">
       <%= render 'shared/components/c_order_filter_button',
-                 text: 'Name',
+                 text: 'ESP Indicator Name',
                  other_class: '-no-wrap',
                  column_key: 'name' %>
     </div>
     <div class="small-2 columns">
       <%= render 'shared/components/c_order_filter_button',
-                 text: 'Based on',
+                 text: "#{@model.abbreviation} Indicator Name",
                  other_class: '-no-wrap',
-                 column_key: 'parent_name' %>
+                 column_key: 'variation_name' %>
     </div>
     <div class="small-2 columns">
       <%= render 'shared/components/c_order_filter_button',
@@ -72,59 +72,11 @@
   </div>
 </div>
 <% @indicators.each do |indicator| %>
-  <div class="c-table-list-item">
-    <div class="row">
-      <div class="small-3 columns">
-        <div class="c-table-list-item__text f-ff1-m-bold">
-          <%= link_to indicator.alias, model_indicator_url(@model, indicator) %>
-        </div>
-      </div>
-      <div class="small-2 columns">
-        <div class="c-table-list-item__text f-ff1-m-bold">
-          <% if indicator.variation? %>
-            <%= link_to indicator.parent.alias, model_indicator_url(@model, indicator.parent) %>
-          <% end %>
-        </div>
-      </div>
-      <div class="small-2 columns">
-        <div class="c-table-list-item__text f-ff1-m"><%= indicator.unit %></div>
-      </div>
-      <div class="small-3 columns">
-        <div class="c-table-list-item__text f-ff1-m">
-          <%= indicator.definition && truncate(indicator.definition, length: 120) %>
-        </div>
-      </div>
-      <div class="small-2 columns">
-        <div class="c-table-list-item__actions">
-          <% if current_user.can?(:destroy, indicator) %>
-            <%= link_to model_indicator_url(@model, indicator), method: :delete, data: {confirm: destroy_confirmation_message(indicator)} do %>
-              <div class="c-remove-button">
-                <svg class="icon"><use xlink:href="#icon-delete"></use></svg>
-                <div class="f-ff1-s">Delete</div>
-              </div>
-            <% end %>
-          <% end %>
-          <% if current_user.can?(:manage, indicator) %>
-            <%= link_to edit_model_indicator_url(@model, indicator) do %>
-              <div class="c-edit-button">
-                <div class="c-edit-button__bubble">
-                  <svg class="icon"><use xlink:href="#icon-edit"></use></svg>
-                </div>
-                <div class="f-ff1-s">Edit</div>
-              </div>
-            <% end %>
-          <% else %>
-            <%= link_to fork_model_indicator_url(@model, indicator) do %>
-              <div class="c-edit-button">
-                <div class="c-edit-button__bubble">
-                  <svg class="icon"><use xlink:href="#icon-edit"></use></svg>
-                </div>
-                <div class="f-ff1-s">Fork</div>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  </div>
+  <% if indicator.variations.any? %>
+    <% indicator.variations.where(model_id: @model.id).each do |variation| %>
+      <%= render partial: 'row', locals: {indicator: indicator, variation: variation} %>
+    <% end %>
+  <% else %>
+    <%= render partial: 'row', locals: {indicator: indicator, variation: nil} %>
+  <% end %>
 <% end %>

--- a/app/views/indicators/_row.html.erb
+++ b/app/views/indicators/_row.html.erb
@@ -1,0 +1,58 @@
+<div class="c-table-list-item">
+  <div class="row">
+    <div class="small-3 columns">
+      <div class="c-table-list-item__text f-ff1-m-bold">
+        <%= link_to indicator.alias, model_indicator_url(@model, indicator) %>
+      </div>
+    </div>
+    <div class="small-2 columns">
+      <div class="c-table-list-item__text f-ff1-m-bold">
+        <% if variation.present? %>
+          <%= link_to variation.alias, model_indicator_url(@model, variation) %>
+        <% end %>
+      </div>
+    </div>
+    <div class="small-2 columns">
+      <div class="c-table-list-item__text f-ff1-m"><%= indicator.unit %></div>
+    </div>
+    <div class="small-3 columns">
+      <div class="c-table-list-item__text f-ff1-m">
+        <%= indicator.definition && truncate(indicator.definition, length: 120) %>
+      </div>
+    </div>
+    <div class="small-2 columns">
+      <div class="c-table-list-item__actions">
+        <% action_indicator = variation || indicator %>
+        <% if current_user.can?(:destroy, action_indicator) %>
+          <%= link_to model_indicator_url(@model, action_indicator),
+            method: :delete,
+            data: {confirm: destroy_confirmation_message(action_indicator)} do %>
+            <div class="c-remove-button">
+              <svg class="icon"><use xlink:href="#icon-delete"></use></svg>
+              <div class="f-ff1-s">Delete</div>
+            </div>
+          <% end %>
+        <% end %>
+        <% if current_user.can?(:manage, action_indicator) %>
+          <%= link_to edit_model_indicator_url(@model, action_indicator) do %>
+            <div class="c-edit-button">
+              <div class="c-edit-button__bubble">
+                <svg class="icon"><use xlink:href="#icon-edit"></use></svg>
+              </div>
+              <div class="f-ff1-s">Edit</div>
+            </div>
+          <% end %>
+        <% else %>
+          <%= link_to fork_model_indicator_url(@model, action_indicator) do %>
+            <div class="c-edit-button">
+              <div class="c-edit-button__bubble">
+                <svg class="icon"><use xlink:href="#icon-edit"></use></svg>
+              </div>
+              <div class="f-ff1-s">Fork</div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/indicators/_row.html.erb
+++ b/app/views/indicators/_row.html.erb
@@ -2,13 +2,15 @@
   <div class="row">
     <div class="small-3 columns">
       <div class="c-table-list-item__text f-ff1-m-bold">
-        <%= link_to indicator.alias, model_indicator_url(@model, indicator) %>
+        <%= link_to indicator.build_alias, model_indicator_url(@model, indicator) %>
       </div>
     </div>
     <div class="small-2 columns">
       <div class="c-table-list-item__text f-ff1-m-bold">
         <% if variation.present? %>
           <%= link_to variation.alias, model_indicator_url(@model, variation) %>
+        <% elsif indicator.team? %>
+          <%= link_to indicator.alias, model_indicator_url(@model, indicator) %>
         <% end %>
       </div>
     </div>

--- a/lib/modules/indicators_data.rb
+++ b/lib/modules/indicators_data.rb
@@ -37,7 +37,7 @@ class IndicatorsData
     id_attributes = Indicator.slug_to_hash(slug)
     stackable_subcategory_raw = value_for(row, :stackable_subcategory)
     stackable_subcategory = stackable_subcategory_raw &&
-      stackable_subcategory_raw.downcase == 'yes'
+      stackable_subcategory_raw.casecmp?('yes')
 
     common_attributes = {
       stackable_subcategory: stackable_subcategory,
@@ -46,13 +46,13 @@ class IndicatorsData
       conversion_factor: value_for(row, :conversion_factor),
       definition: value_for(row, :definition)
     }
-    if !model_slug.present?
+    if !model_slug.present? || @user.admin?
       process_system_indicator(id_attributes, common_attributes, row_no)
-    else
-      process_team_variation(
-        id_attributes, common_attributes, slug, model_slug, row_no
-      )
     end
+    return unless model_slug.present?
+    process_team_variation(
+      id_attributes, common_attributes, slug, model_slug, row_no
+    )
   end
 
   def process_system_indicator(id_attributes, common_attributes, row_no)

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -5,20 +5,20 @@ RSpec.describe IndicatorsController, type: :controller do
     login_admin
     let(:team_model) { FactoryGirl.create(:model) }
     let(:some_model) { FactoryGirl.create(:model) }
-    let(:team_indicator) { FactoryGirl.create(:indicator, model: team_model) }
-    let(:some_indicator) { FactoryGirl.create(:indicator, model: some_model) }
-    let(:master_indicator) { FactoryGirl.create(:indicator, model: nil) }
+    let!(:team_indicator) { FactoryGirl.create(:indicator, model: team_model) }
+    let!(:some_indicator) { FactoryGirl.create(:indicator, model: some_model) }
+    let!(:master_indicator) { FactoryGirl.create(:indicator, model: nil) }
 
     describe 'GET index' do
       it 'assigns all indicators for own team\'s model' do
         get :index, params: {model_id: team_model.id}
-        expect(assigns(:indicators)).to eq(
+        expect(assigns(:indicators)).to match_array(
           [team_indicator, some_indicator, master_indicator]
         )
       end
       it 'assigns all indicators for other team\'s model' do
         get :index, params: {model_id: some_model.id}
-        expect(assigns(:indicators)).to eq(
+        expect(assigns(:indicators)).to match_array(
           [team_indicator, some_indicator, master_indicator]
         )
       end
@@ -166,7 +166,9 @@ RSpec.describe IndicatorsController, type: :controller do
       end
       it 'assigns team and master indicators' do
         get :index, params: {model_id: team_model.id}
-        expect(assigns(:indicators)).to eq([team_indicator, master_indicator])
+        expect(
+          assigns(:indicators)
+        ).to match_array([team_indicator, master_indicator])
       end
       it 'prevents unauthorized access' do
         get :index, params: {model_id: some_model.id}

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -181,51 +181,6 @@ RSpec.describe Indicator, type: :model do
     end
   end
 
-  describe :for_model do
-    let(:model1) { FactoryGirl.create(:model) }
-    let(:model2) { FactoryGirl.create(:model) }
-    let!(:core_indicator1) {
-      FactoryGirl.create(
-        :indicator,
-        category: 'Emissions', subcategory: 'CO2 by sector', name: 'buildings'
-      )
-    }
-    let!(:core_indicator2) {
-      FactoryGirl.create(
-        :indicator,
-        category: 'Emissions', subcategory: 'CO2 by sector', name: 'transport'
-      )
-    }
-    let!(:team_indicator1) {
-      FactoryGirl.create(
-        :indicator,
-        parent: nil,
-        model: model1,
-        category: 'Emissions', subcategory: 'CO2 by sector',
-        name: 'residential',
-        alias: 'Emissions|My custom|residential CO2'
-      )
-    }
-    let!(:team_variation1) {
-      FactoryGirl.create(
-        :indicator,
-        parent: core_indicator1,
-        model: model1,
-        alias: "#{model1.abbreviation} #{core_indicator1.alias}"
-      )
-    }
-    it 'returns core and team indicators' do
-      expect(Indicator.for_model(model2)).to match_array(
-        [core_indicator1, core_indicator2]
-      )
-    end
-    it 'returns core and team indicators' do
-      expect(Indicator.for_model(model1)).to match_array(
-        [core_indicator1, core_indicator2, team_indicator1]
-      )
-    end
-  end
-
   describe :scenarios do
     let(:indicator) { FactoryGirl.create(:indicator) }
     let(:scenario) { FactoryGirl.create(:scenario) }

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -212,14 +212,16 @@ RSpec.describe Indicator, type: :model do
       FactoryGirl.create(
         :indicator,
         category: 'Emissions', subcategory: 'CO2 by sector', name: 'Industry',
-        model: model
+        model: model,
+        alias: 'Hello|My|Custom2'
       )
     }
     let!(:other_indicator) {
       FactoryGirl.create(
         :indicator,
         category: 'Emissions', subcategory: 'CO2 by sector', name: 'Transport',
-        model: FactoryGirl.create(:model)
+        model: FactoryGirl.create(:model),
+        alias: 'Hello|My|Custom1'
       )
     }
     context 'when using filters' do
@@ -257,15 +259,25 @@ RSpec.describe Indicator, type: :model do
       end
     end
     context 'when sorting' do
-      it 'orders by name' do
+      let!(:variation) {
+        FactoryGirl.create(
+          :indicator,
+          parent: system_indicator,
+          model: model,
+          alias: 'Goodbye|My|Custom'
+        )
+      }
+      it 'orders by ESP name' do
         expect(
-          Indicator.fetch_all('order_type' => 'name')
-        ).to eq([system_indicator, team_indicator, other_indicator])
-      end
-      it 'orders by slug' do
-        expect(
-          Indicator.fetch_all('order_type' => 'alias')
+          Indicator.system_indicators_with_variations.
+            fetch_all('order_type' => 'esp_name')
         ).to eq([team_indicator, other_indicator, system_indicator])
+      end
+      it 'orders by model name' do
+        expect(
+          Indicator.system_indicators_with_variations.
+            fetch_all('order_type' => 'model_name')
+        ).to eq([system_indicator, other_indicator, team_indicator])
       end
     end
   end

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -184,25 +184,44 @@ RSpec.describe Indicator, type: :model do
   describe :for_model do
     let(:model1) { FactoryGirl.create(:model) }
     let(:model2) { FactoryGirl.create(:model) }
-    let!(:core_indicator1) { FactoryGirl.create(:indicator) }
-    let!(:core_indicator2) { FactoryGirl.create(:indicator) }
+    let!(:core_indicator1) {
+      FactoryGirl.create(
+        :indicator,
+        category: 'Emissions', subcategory: 'CO2 by sector', name: 'buildings'
+      )
+    }
+    let!(:core_indicator2) {
+      FactoryGirl.create(
+        :indicator,
+        category: 'Emissions', subcategory: 'CO2 by sector', name: 'transport'
+      )
+    }
     let!(:team_indicator1) {
-      FactoryGirl.create(:indicator, parent: nil, model: model1)
+      FactoryGirl.create(
+        :indicator,
+        parent: nil,
+        model: model1,
+        category: 'Emissions', subcategory: 'CO2 by sector',
+        name: 'residential',
+        alias: 'Emissions|My custom|residential CO2'
+      )
     }
     let!(:team_variation1) {
-      FactoryGirl.create(:indicator, parent: core_indicator1, model: model1)
-    }
-    let!(:team_variation2) {
-      FactoryGirl.create(:indicator, parent: team_indicator1, model: model1)
+      FactoryGirl.create(
+        :indicator,
+        parent: core_indicator1,
+        model: model1,
+        alias: "#{model1.abbreviation} #{core_indicator1.alias}"
+      )
     }
     it 'returns core and team indicators' do
       expect(Indicator.for_model(model2)).to match_array(
-        [core_indicator1, core_indicator2, team_indicator1]
+        [core_indicator1, core_indicator2]
       )
     end
-    it 'returns core, team and variation indicators' do
+    it 'returns core and team indicators' do
       expect(Indicator.for_model(model1)).to match_array(
-        [team_variation1, core_indicator2, team_variation2]
+        [core_indicator1, core_indicator2, team_indicator1]
       )
     end
   end


### PR DESCRIPTION
The columns have been changed as specified, with the ESP name in the first column and the model name in the second.
- If the displayed indicator is a variation, then the first column will link to a core indicator, and the second to the variation, whereas the edit / delete buttons go to the variation.
- If the displayed indicator is a team indicator, then the first column links to it via an ESP-compliant slug made up of category, subcategory and name, whereas the second column links to it via the alias field, which is the model-specific name; the edit / delete link go to the team indicator as well.

