### PR TITLE
Simplifies creating variations via form

### DIFF
--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -20,7 +20,9 @@ class IndicatorsController < ApplicationController
 
   def create
     @indicator = Indicator.new(indicator_params)
-    @indicator.model = @model unless current_user.admin?
+    unless current_user.admin? && @indicator.parent_id.nil?
+      @indicator.model = @model
+    end
     if @indicator.save
       redirect_to model_indicator_url(@model, @indicator),
                   notice: 'Indicator was successfully created.'

--- a/app/models/concerns/alias_transformations.rb
+++ b/app/models/concerns/alias_transformations.rb
@@ -9,10 +9,22 @@ module AliasTransformations
     before_save :update_alias, if: proc { |i|
       i.parent_id.blank? && (i.model_id.blank? || i.alias.blank?)
     }
+    # copy shared attributes from parent if variation
+    before_validation :copy_from_parent, if: proc { |i|
+      i.parent_id.present?
+    }
   end
 
   def build_alias
     [category, subcategory, name].join('|').chomp('|')
+  end
+
+  def copy_from_parent
+    self.category = parent.category
+    self.subcategory = parent.subcategory
+    self.name = parent.name
+    self.stackable_subcategory = parent.stackable_subcategory
+    self.unit = parent.unit
   end
 
   def update_alias

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe IndicatorsController, type: :controller do
           model_indicator_url(some_model, assigns(:indicator))
         )
       end
+
+      it 'redirects to own team\'s variation when successful' do
+        post :create, params: {
+          model_id: team_model.id, indicator: {
+            parent_id: master_indicator.id,
+            alias: 'Hello|variation',
+            unit_of_entry: master_indicator.unit
+          }
+        }
+        expect(response).to redirect_to(
+          model_indicator_url(team_model, assigns(:indicator))
+        )
+      end
     end
 
     describe 'GET edit' do
@@ -206,6 +219,19 @@ RSpec.describe IndicatorsController, type: :controller do
         )
       end
 
+      it 'redirects to own team\'s variation when successful' do
+        post :create, params: {
+          model_id: team_model.id, indicator: {
+            parent_id: master_indicator.id,
+            alias: 'Hello|variation',
+            unit_of_entry: master_indicator.unit
+          }
+        }
+        expect(response).to redirect_to(
+          model_indicator_url(team_model, assigns(:indicator))
+        )
+      end
+
       it 'prevents unauthorized access' do
         post :create, params: {
           model_id: some_model.id, indicator: {category: ['Buildings']}
@@ -232,7 +258,7 @@ RSpec.describe IndicatorsController, type: :controller do
             post :create, params: {
               model_id: team_model.id, indicator: {
                 parent_id: some_indicator.id, category: ['Transportation'],
-                unit: ['m']
+                unit_of_entry: ['m']
               }
             }
           }.not_to(change { Indicator.count })


### PR DESCRIPTION
This fixes 2 issues I noticed when trying to add indicator variations via form rather than upload:
- it was impossible to create a variation while logged in as admin, as the system assumed an admin would always create a system indicator,
- it was annoying to create a variation because of mandatory fields required to be filled in and consistent with parent indicator, which resulted in validation errors. Right now all the fields that a variation is supposed to share with parent (category, subcategory, name, stackable category, unit) are copied over from parent before validation.