### PR TITLE
Fix/model page crashing when empty sectoral coverage

### DIFF
--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -35,7 +35,7 @@
                    },
                    {
                      title: 'Sector focus',
-                     data: @model.sectoral_coverage.join(', ')
+                     data: @model.sectoral_coverage.try(:join, ', ')
                    },
                    {
                      title: 'Time horizon',

--- a/lib/modules/csv_vertical_upload_data.rb
+++ b/lib/modules/csv_vertical_upload_data.rb
@@ -83,7 +83,7 @@ module CsvVerticalUploadData
     return nil unless index
     value = col[index]
     if multiple_selection?(property_name)
-      value = value.split(';').map(&:strip) unless value.blank?
+      value = value.present? && value.split(';').map(&:strip) || []
     end
     value
   end


### PR DESCRIPTION
Fixes the upload process so that it saves blank array properties as empty array instead of nil. Adds a check when displaying the value as there's no `not null` constraint on the db so in reality this could still be nil.