### PR TITLE
Fixes issues with duplicated records caused by trailing whitespace

### DIFF
--- a/app/models/concerns/alias_transformations.rb
+++ b/app/models/concerns/alias_transformations.rb
@@ -9,10 +9,22 @@ module AliasTransformations
     before_save :update_alias, if: proc { |i|
       i.parent_id.blank? && (i.model_id.blank? || i.alias.blank?)
     }
+
     # copy shared attributes from parent if variation
     before_validation :copy_from_parent, if: proc { |i|
       i.parent_id.present?
     }
+
+    # ensure no trailing whitespace in attributes used for matching
+    before_validation :strip_whitespace
+  end
+
+  def strip_whitespace
+    self.category = category.try(:strip)
+    self.subcategory = subcategory.try(:strip)
+    self.name = name.try(:strip)
+    self.unit = unit.try(:strip)
+    self.unit_of_entry = unit_of_entry.try(:strip)
   end
 
   def build_alias

--- a/lib/modules/csv_upload_data.rb
+++ b/lib/modules/csv_upload_data.rb
@@ -44,7 +44,7 @@ module CsvUploadData
   def value_for(row, property_name)
     index = @headers.actual_index_for_property(property_name)
     return nil unless index
-    row[index]
+    row[index] && row[index].strip || nil
   end
 
   def matching_object(

--- a/lib/modules/csv_vertical_upload_data.rb
+++ b/lib/modules/csv_vertical_upload_data.rb
@@ -83,8 +83,9 @@ module CsvVerticalUploadData
     return nil unless index
     value = col[index]
     if multiple_selection?(property_name)
-      value = value.present? && value.split(';').map(&:strip) || []
+      value.present? && value.split(';').map(&:strip) || []
+    else
+      value.try(:strip)
     end
-    value
   end
 end

--- a/spec/fixtures/indicators-correct.csv
+++ b/spec/fixtures/indicators-correct.csv
@@ -1,3 +1,3 @@
 ESP Indicator Name,Model A Indicator Name,Stackable sub-category?,Standardized Unit,Unit of Entry,Conversion factor,Definition,
 Emissions|CO2 by sector|electricity,,yes,Mt CO2e/yr,Mt CO2e/yr,,"carbon dioxide emissions from the industrial sector, including feedstocks, including agriculture and fishing",
-Emissions|CO2 by sector|industry,Emissions|CO2|Fossil Fuels and Industry|Energy Demand|Industry,yes,Mt CO2e/yr,Mt CO2e/yr,,"carbon dioxide emissions from the industrial sector, including feedstocks, including agriculture and fishing",
+Emissions|CO2 by sector|industry ,Emissions|CO2|Fossil Fuels and Industry|Energy Demand|Industry,yes,Mt CO2e/yr,Mt CO2e/yr,,"carbon dioxide emissions from the industrial sector, including feedstocks, including agriculture and fishing",


### PR DESCRIPTION
Trailing whitespace in indicator names might have been one of the reasons for duplicated indicators being created. I'll keep looking in case there might be others.