### PR TITLE
Fetch indicators with variation names for scenario indicators list

### DIFF
--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -27,10 +27,9 @@ class ScenariosController < ApplicationController
   end
 
   def show
-    @indicators = @scenario.indicators.fetch_all(@filter_params)
-    @indicator_categories = Indicator.except(:order).
-      order(:category).
-      distinct.pluck(:category)
+    @indicators = Indicator.
+      system_indicators_with_variations_for_scenario(@scenario.id).
+      fetch_all(@filter_params)
   end
 
   def destroy

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -39,6 +39,13 @@ variations.model_id").
       joins("LEFT JOIN teams variations_teams ON variations_teams.id = \
 variations_models.team_id")
   }
+  scope :system_indicators_with_variations_for_scenario, lambda { |scenario_id|
+    subquery = TimeSeriesValue.where(scenario_id: scenario_id).
+      select(:indicator_id).group(:indicator_id).to_sql
+    system_indicators_with_variations.
+      joins("JOIN (#{subquery}) s ON variations.id = s.indicator_id")
+  }
+
   pg_search_scope :search_for, against: [
     :category, :subcategory, :name, :alias
   ]


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/150402040

The issue was that last time the main list of indicators was overhauled to show the two names side by side the list on scenario page was not updated to match.