### PR TITLE
Fix/issues with duplicates on two segment indicator names

### DIFF
--- a/app/models/concerns/alias_transformations.rb
+++ b/app/models/concerns/alias_transformations.rb
@@ -68,16 +68,18 @@ module AliasTransformations
   class_methods do
     def slug_to_hash(slug)
       return {} unless slug.present?
-      slug_parts = slug && slug.split('|', 3)
+      slug_parts = slug && slug.split('|', 3).map(&:strip)
       return {} if slug_parts.empty?
       slug_parts_to_hash(slug_parts)
     end
 
     def slug_parts_to_hash(slug_parts)
-      slug_hash = {category: fix_category_capitalisation(slug_parts[0].strip)}
+      slug_hash = {category: fix_category_capitalisation(slug_parts[0])}
       if slug_parts.length >= 2
-        slug_hash[:subcategory] = slug_parts[1].strip
-        slug_hash[:name] = slug_parts[2].strip if slug_parts.length == 3
+        slug_hash[:subcategory] = slug_parts[1]
+        if slug_parts.length == 3 && slug_parts[2].present?
+          slug_hash[:name] = slug_parts[2]
+        end
       end
       slug_hash
     end

--- a/app/models/concerns/alias_transformations.rb
+++ b/app/models/concerns/alias_transformations.rb
@@ -77,9 +77,7 @@ module AliasTransformations
       slug_hash = {category: fix_category_capitalisation(slug_parts[0])}
       if slug_parts.length >= 2
         slug_hash[:subcategory] = slug_parts[1].presence
-        if slug_parts.length == 3
-          slug_hash[:name] = slug_parts[2].presence
-        end
+        slug_hash[:name] = slug_parts[2].presence if slug_parts.length == 3
       end
       slug_hash
     end

--- a/app/models/concerns/alias_transformations.rb
+++ b/app/models/concerns/alias_transformations.rb
@@ -76,9 +76,9 @@ module AliasTransformations
     def slug_parts_to_hash(slug_parts)
       slug_hash = {category: fix_category_capitalisation(slug_parts[0])}
       if slug_parts.length >= 2
-        slug_hash[:subcategory] = slug_parts[1]
-        if slug_parts.length == 3 && slug_parts[2].present?
-          slug_hash[:name] = slug_parts[2]
+        slug_hash[:subcategory] = slug_parts[1].presence
+        if slug_parts.length == 3
+          slug_hash[:name] = slug_parts[2].presence
         end
       end
       slug_hash

--- a/db/remove_duplicated_system_indicators.sql
+++ b/db/remove_duplicated_system_indicators.sql
@@ -1,0 +1,25 @@
+WITH duplicated_system_indicators AS (
+  SELECT min_id, dup_id FROM (
+    SELECT min_id, UNNEST(duplicated_ids) AS dup_id FROM (
+      SELECT category, subcategory, name, MIN(id) AS min_id, ARRAY_AGG(id) AS duplicated_ids, COUNT(*)
+      FROM indicators
+      WHERE parent_id IS NULL AND model_id IS NULL
+      GROUP BY (category, subcategory, name)
+      HAVING COUNT(*) > 1
+    ) s
+  ) ss
+  WHERE ss.dup_id != ss.min_id
+), updated_variations AS (
+  UPDATE indicators i
+  SET parent_id = d.min_id
+  FROM duplicated_system_indicators d
+  WHERE d.dup_id = i.parent_id
+), updated_values AS (
+  UPDATE time_series_values ts
+  SET indicator_id = d.min_id
+  FROM duplicated_system_indicators d
+  WHERE d.dup_id = ts.indicator_id
+)
+DELETE FROM indicators
+USING duplicated_system_indicators d
+WHERE indicators.id = d.dup_id;

--- a/lib/modules/indicators_data.rb
+++ b/lib/modules/indicators_data.rb
@@ -65,7 +65,13 @@ indicator instead.'
       )
       return nil
     end
-    indicator = Indicator.where(id_attributes).first
+    indicator = Indicator.where(id_attributes.slice(:category, :subcategory))
+    indicator =
+      if id_attributes[:name].blank?
+        indicator.where('name IS NULL OR name = ?', '')
+      else
+        indicator.where(name: id_attributes[:name])
+      end.first
     attributes = id_attributes.merge(common_attributes).merge(
       model_id: nil,
       parent_id: nil

--- a/lib/modules/indicators_data.rb
+++ b/lib/modules/indicators_data.rb
@@ -65,13 +65,16 @@ indicator instead.'
       )
       return nil
     end
-    indicator = Indicator.where(id_attributes.slice(:category, :subcategory))
-    indicator =
-      if id_attributes[:name].blank?
-        indicator.where('name IS NULL OR name = ?', '')
-      else
-        indicator.where(name: id_attributes[:name])
-      end.first
+    indicator = Indicator.where(category: id_attributes[:category])
+    [:subcategory, :name].each do |name_part|
+      indicator =
+        if id_attributes[name_part].blank?
+          indicator.where("#{name_part} IS NULL OR #{name_part} = ?", '')
+        else
+          indicator.where(name_part => id_attributes[name_part])
+        end
+    end
+    indicator = indicator.first
     attributes = id_attributes.merge(common_attributes).merge(
       model_id: nil,
       parent_id: nil

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Indicator, type: :model do
     it 'parses a 3-part slug with blank subcategory' do
       expect(
         Indicator.slug_to_hash('A||B')
-      ).to eq(category: 'A', subcategory: '', name: 'B')
+      ).to eq(category: 'A', subcategory: nil, name: 'B')
     end
     it 'parses a 2-part slug' do
       expect(


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/150740141 by enforcing an explicit check for empty or NULL subcategory or name when matching against existing indicators.