### PR TITLE
Display information about type of indicator / model it belongs to

### DIFF
--- a/app/assets/stylesheets/layouts/_l-indicators-overview.scss
+++ b/app/assets/stylesheets/layouts/_l-indicators-overview.scss
@@ -8,6 +8,11 @@
     padding: rem(3px) 0 rem(12px) 0;
   }
 
+  .l-indicators-overview__hierarchy_info {
+    padding: rem(3px) rem(6px) rem(3px) rem(6px);
+    border: 2px dashed rgba(51, 51, 51, 0.3)
+  }
+
   .l-indicators-overview__data {
     margin-top: rem(6px);
   }

--- a/app/views/indicators/show.html.erb
+++ b/app/views/indicators/show.html.erb
@@ -76,27 +76,41 @@
       </div>
     </div>
   </div>
-  <% if (@indicator.system? || @indicator.team?) && @indicator.variations.any? %>
-    <div class="row">
-      <div class="small-12 columns">
-        <div class="l-indicators-overview__table-title f-ff3-m-bold">Variations <span>(<%= @indicator.variations.length %>)</span></div>
-        <% @indicator.variations.each do |variation| %>
-          <div class="f-ff1-m l-indicators-overview__data">
-            <%= link_to variation.alias, model_indicator_url(variation.model, variation) %>
-          </div>
+
+  <div class="row">
+    <div class="small-9 columns">
+      <div class="l-indicators-overview__hierarchy_info">
+        <% if @indicator.system? %>
+          <p>This is a <span class="f-ff1-m-bold">system indicator</span>.</p>
+        <% elsif @indicator.team? %>
+          <p>This is a <span class="f-ff1-m-bold">team indicator</span>.</p>
+        <% else %>
+          <p>This is a <span class="f-ff1-m-bold">variation of <%= link_to @indicator.parent.alias, model_indicator_url(@indicator.model, @indicator.parent) %></span></p>
+        <% end %>
+        <% if @indicator.model.present? %>
+          <p>
+            <span class="f-ff1-m-bold">Model:</span>
+            <%= link_to @indicator.model.abbreviation, model_url(@indicator.model) %>
+          </p>
+          <% if @indicator.model.team.present? && current_user.admin? %>
+            <p>
+              <span class="f-ff1-m-bold">Team:</span>
+              <%= link_to @indicator.model.team.name, edit_team_url(@indicator.model.team) %>
+            </p>
+          <% end %>
+        <% end %>
+        <% if (@indicator.system? || @indicator.team?) && @indicator.variations.any? %>
+          <p>The following variations exist:</p>
+          <% @indicator.variations.each do |variation| %>
+            <p class="f-ff1-m-bold">
+              <%= link_to variation.alias, model_indicator_url(variation.model, variation) %>
+            </p>
+          <% end %>
         <% end %>
       </div>
     </div>
-  <% elsif @indicator.variation? %>
-      <div class="row">
-      <div class="small-12 columns">
-        <div class="l-indicators-overview__table-title f-ff3-m-bold">
-          Variation of:
-          <%= link_to @indicator.parent.alias, model_indicator_url(@indicator.model, @indicator.parent) %>
-        </div>
-      </div>
-    </div>
-  <% end %>
+  </div>
+
   <div class="row">
     <div class="small-9 columns">
       <div class="l-indicators-overview__table-title f-ff3-m-bold">Time Series <span>(<%= @time_series_values_pivot[:data].length %>)</span></div>


### PR DESCRIPTION
Hopefully this addresses:

https://www.pivotaltracker.com/story/show/150841939

I put a dashed border around this part of the page because it was blending too much with the rest of it:

![image](https://user-images.githubusercontent.com/134055/30110086-b8e79944-9300-11e7-906c-8e909d819284.png)

![image](https://user-images.githubusercontent.com/134055/30110096-c1009a22-9300-11e7-8631-0d23fdde8da4.png)

![image](https://user-images.githubusercontent.com/134055/30110101-c72f4948-9300-11e7-8de3-11a8a93ac3ad.png)

