### PR TITLE
Feature/add category entity and endpoint

### DIFF
--- a/app/assets/javascripts/controllers/categories_controllers.js
+++ b/app/assets/javascripts/controllers/categories_controllers.js
@@ -1,0 +1,21 @@
+(function(App) {
+console.log("woopy");
+  'use strict';
+
+  App.Controller = App.Controller || {};
+
+  App.Controller.Categories = App.Controller.Page.extend({
+
+    index: function () {
+      new App.View.Filters({});
+      new App.View.Form();
+    },
+
+    edit: function () {
+      new App.View.FormVerticalNav();
+      new App.View.Form();
+    }
+
+  });
+
+})(this.App);

--- a/app/assets/javascripts/controllers/categories_controllers.js
+++ b/app/assets/javascripts/controllers/categories_controllers.js
@@ -1,5 +1,4 @@
 (function(App) {
-console.log("woopy");
   'use strict';
 
   App.Controller = App.Controller || {};

--- a/app/assets/javascripts/controllers/indicators_controllers.js
+++ b/app/assets/javascripts/controllers/indicators_controllers.js
@@ -4,6 +4,50 @@
 
   App.Controller = App.Controller || {};
 
+  App.Data = {};
+
+  var getCategories = function() {
+    var grouped = _.groupBy(App.Data.categories, function(category) {
+      return category.parent_id;
+    });
+
+    Object.keys(grouped).forEach(function(parent_id) {
+      grouped[parent_id] = grouped[parent_id].map(function(category) {
+        return String(category.id);
+      });
+    });
+
+    return grouped;
+  }
+
+  var initializeSelectBehaviour = function() {
+    var $categorySelect = $('select[name="indicator[category_id]"]');
+    var $subcategorySelect = $('select[name="indicator[subcategory_id]"]');
+
+    $categorySelect.change(function() {
+      var subcategory_ids = getCategories()[this.value];
+        $subcategorySelect.find('option').each(function() {
+        if (_.isEmpty(subcategory_ids) && this.value != '') {
+          $(this).attr('disabled', 'disabled');
+        } else if (_.includes(subcategory_ids, this.value) || this.value == '') {
+          $(this).removeAttr('disabled');
+        } else {
+          $(this).attr('disabled', 'disabled');
+        }
+      });
+
+      if (!_.includes(subcategory_ids, $subcategorySelect.val())) {
+        $subcategorySelect.val('')
+      }
+
+      $subcategorySelect.select2({
+        minimumResultsForSearch: Infinity
+      });
+    });
+
+    $categorySelect.trigger('change');
+  }
+
   App.Controller.Indicators = App.Controller.Page.extend({
 
     index: function () {
@@ -24,9 +68,15 @@
 
     edit: function () {
       new App.View.Form();
+      initializeSelectBehaviour();
     },
 
-    fork: function () {
+    'new': function () {
+      new App.View.Form();
+      initializeSelectBehaviour();
+    },
+
+    fork: function() {
       new App.View.Form();
     }
 

--- a/app/assets/stylesheets/layouts/_l-categories-edit.scss
+++ b/app/assets/stylesheets/layouts/_l-categories-edit.scss
@@ -1,0 +1,73 @@
+.l-categories-edit {
+  padding: rem(20px) 0;
+
+  .c-checkbox {
+    display: inline-block;
+    top: rem(9px);
+  }
+
+  .l-categories-edit__form-action {
+    text-decoration: none;
+  }
+
+  .c-vertical-nav {
+    padding-top: rem(64px);
+
+    &.-fixed {
+      position: fixed;
+      top: 0;
+    }
+  }
+
+  .c-form {
+    margin-top: rem(20px);
+  }
+
+  .l-categories-edit__form-subcategories {
+    border-bottom: 0;
+  }
+
+  .l-categories-edit__subcategory {
+
+    li {
+      &:not(:last-of-type) {
+        margin-bottom: rem(20px);
+      }
+    }
+
+    .c-checkbox {
+      display: inline-block;
+      top: rem(9px);
+    }
+
+    .c-remove-button {
+      display: inline-block;
+      position: relative;
+      top: rem(5px);
+      margin-left: rem(14px);
+    }
+  }
+
+  .l-categories-edit__form-add-subcategories {
+    margin-top: 0;
+    border-top: 0;
+
+    .c-form-items {
+      padding-top: 0;
+    }
+  }
+
+  .l-categories-edit__add-subcategory {
+
+    .c-input-text {
+      display: inline-block;
+      max-width: rem(320px);
+      margin-right: rem(16px);
+    }
+
+    .c-button {
+      display: inline-block;
+      max-width: rem(70px);
+    }
+  }
+}

--- a/app/assets/stylesheets/layouts/_l-categories.scss
+++ b/app/assets/stylesheets/layouts/_l-categories.scss
@@ -1,0 +1,14 @@
+.l-categories {
+  padding-top: rem(30px);
+
+  .l-categories__title {
+    position: relative;
+    top: rem(10px);
+  }
+
+  .l-categories__table-shorts {
+    position: relative;
+    padding: rem(23px) 0 rem(7px) 0;
+    box-shadow: 0 3px 5px 0 $color-app-5;
+  }
+}

--- a/app/assets/stylesheets/layouts/_l-indicator-edit.scss
+++ b/app/assets/stylesheets/layouts/_l-indicator-edit.scss
@@ -13,3 +13,7 @@
     margin-bottom: rem(20px);
   }
 }
+
+.select2-results__option[aria-disabled="true"] {
+  display: none;
+}

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,6 +6,7 @@ class AdminController < ApplicationController
     @models = Model.order(:abbreviation)
     @locations = Location.order(:name)
     @indicators = Indicator.where(parent_id: nil)
+    @categories = Category.where(parent_id: nil).order(:name)
   end
 
   private

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -2,9 +2,7 @@ module Api
   module V1
     class CategoriesController < ApiController
       def index
-        categories = Category.
-          order(:name).
-          all
+        categories = Category.order(:name).all
 
         render json: categories
       end

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  module V1
+    class CategoriesController < ApiController
+      def index
+        categories = Category.
+          order(:name).
+          all
+
+        render json: categories
+      end
+    end
+  end
+end
+

--- a/app/controllers/api/v1/indicators_controller.rb
+++ b/app/controllers/api/v1/indicators_controller.rb
@@ -3,6 +3,7 @@ module Api
     class IndicatorsController < ApiController
       def index
         indicators = Indicator.
+          includes(category: :parent).
           order(:name).
           all
 
@@ -11,6 +12,7 @@ module Api
 
       def show
         indicator = Indicator.
+          includes(category: :parent).
           find_by!(id: params[:id])
 
         render json: indicator

--- a/app/controllers/api/v1/indicators_controller.rb
+++ b/app/controllers/api/v1/indicators_controller.rb
@@ -3,7 +3,17 @@ module Api
     class IndicatorsController < ApiController
       def index
         indicators = Indicator.
-          includes(category: :parent).
+          includes(category: :parent)
+
+        if params[:category]
+          indicators = indicators.where(
+            categories: {id: params[:category]}
+          ).or(indicators.where(
+            categories: {parent_id: params[:category]}
+          ))
+        end
+
+        indicators = indicators.
           order(:name).
           all
 

--- a/app/controllers/api/v1/indicators_controller.rb
+++ b/app/controllers/api/v1/indicators_controller.rb
@@ -3,13 +3,13 @@ module Api
     class IndicatorsController < ApiController
       def index
         indicators = Indicator.
-          includes(category: :parent)
+          includes(:category, :subcategory)
 
         if params[:category]
           indicators = indicators.where(
-            categories: {id: params[:category]}
+            category_id: params[:category]
           ).or(indicators.where(
-            categories: {parent_id: params[:category]}
+            subcategory_id: params[:category]
           ))
         end
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -61,4 +61,3 @@ class CategoriesController < ApplicationController
       ])
   end
 end
-

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,64 @@
+class CategoriesController < ApplicationController
+  load_and_authorize_resource
+
+  before_action :set_filter_params, only: [:index]
+
+  def index
+    @categories = Category.fetch_all(@filter_params)
+  end
+
+  def new
+    @category = Category.new
+    @parent_categories = Category.where(parent_id: nil)
+    render :edit
+  end
+
+  def edit
+    @parent_categories = Category.where(parent_id: nil)
+  end
+
+  def create
+    @category = Category.new(category_params)
+
+    if @category.save
+      redirect_to edit_category_url(@category),
+                  notice: 'Category was successfully created.'
+    else
+      flash[:alert] =
+        'We could not create the category. Please check the inputs in red'
+      render :edit
+    end
+  end
+
+  def update
+    if @category.update_attributes(category_params)
+      redirect_to edit_category_url(@category),
+                  notice: 'Category was successfully updated.'
+    else
+      flash[:alert] =
+        'We could not update the category. Please check the inputs in red'
+      render :edit
+    end
+  end
+
+  def destroy
+    @category.destroy
+    redirect_to categories_url,
+                notice: 'Category was successfully destroyed.'
+  rescue ActiveRecord::InvalidForeignKey
+    redirect_to(
+      categories_url,
+      alert: 'Could not delete category.'
+    )
+  end
+
+  private
+
+  def category_params
+    params.require(:category).permit(
+      :name, subcategories_attributes: [
+        :id, :name, :stackable
+      ])
+  end
+end
+

--- a/app/controllers/category_subcategories_controller.rb
+++ b/app/controllers/category_subcategories_controller.rb
@@ -1,0 +1,37 @@
+class CategorySubcategoriesController < ApplicationController
+  load_and_authorize_resource :category
+
+  def create
+    subcategory = Category.new(subcategory_params)
+    subcategory.parent_id = params[:category_id]
+    subcategory.save!
+    redirect_to(
+      edit_category_url(subcategory.parent),
+      notice: 'Subcategory successfully added.'
+    )
+  end
+
+  def destroy
+    subcategory = Category.find_by(id: params[:id])
+    subcategory.destroy!
+    redirect_to(
+      edit_category_url(@category),
+      notice: 'Subcategory successfully deleted.'
+    )
+  rescue ActiveRecord::InvalidForeignKey
+    redirect_to(
+      edit_category_url(@category),
+      alert: 'Could not delete subcategory.'
+    )
+  end
+
+  private
+
+  def set_category
+    @category = Category.find(params[:category_id])
+  end
+
+  def subcategory_params
+    params.require(:category).permit(:name, :stackable)
+  end
+end

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -39,7 +39,8 @@ class IndicatorsController < ApplicationController
     end
   end
 
-  def edit; end
+  def edit
+  end
 
   def fork
     if current_user.team.model_ids.include?(@indicator.model_id)

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -15,7 +15,7 @@ class IndicatorsController < ApplicationController
       call(
         Indicator.
           for_model(@model).
-          includes(:time_series_values)
+          includes(:category, :time_series_values)
       )
   end
 

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -47,9 +47,14 @@ class ModelsController < ApplicationController
   def show
     @scenarios = @model.scenarios.limit(5)
     @indicators = Indicator.
+      includes(:category, :subcategory).
       system_and_team.exclude_with_variations_in_model(@model).
-      or(Indicator.model_variations(@model)).
-      order(:category, :subcategory, :name)
+      or(
+        Indicator.
+          includes(:category, :subcategory).
+          model_variations(@model)
+      ).
+      order('categories.name, subcategories_indicators.name, indicators.name')
   end
 
   def destroy

--- a/app/controllers/system_indicators_controller.rb
+++ b/app/controllers/system_indicators_controller.rb
@@ -44,7 +44,6 @@ class SystemIndicatorsController < AdminController
       redirect_to indicator_url(@indicator),
                   notice: 'Indicator was successfully updated.'
     else
-      debugger
       flash[:alert] =
         'We could not update the indicator. Please check the inputs in red'
       render template: 'indicators/edit'

--- a/app/controllers/system_indicators_controller.rb
+++ b/app/controllers/system_indicators_controller.rb
@@ -7,7 +7,12 @@ class SystemIndicatorsController < AdminController
   def index
     @indicators = FilterIndicators.
       new(@filter_params).
-      call(Indicator.system_and_team)
+      call(
+        Indicator.
+          includes(:category, :subcategory, :time_series_values).
+          references(:category, :subcategory).
+          system_and_team
+      )
     render template: 'indicators/index'
   end
 
@@ -24,7 +29,7 @@ class SystemIndicatorsController < AdminController
     else
       flash[:alert] =
         'We could not create the indicator. Please check the inputs in red'
-      render action: :edit
+      render template: 'indicators/edit'
     end
   end
 
@@ -37,9 +42,10 @@ class SystemIndicatorsController < AdminController
       redirect_to indicator_url(@indicator),
                   notice: 'Indicator was successfully updated.'
     else
+      debugger
       flash[:alert] =
         'We could not update the indicator. Please check the inputs in red'
-      render action: :edit
+      render template: 'indicators/edit'
     end
   end
 

--- a/app/controllers/system_indicators_controller.rb
+++ b/app/controllers/system_indicators_controller.rb
@@ -18,6 +18,7 @@ class SystemIndicatorsController < AdminController
 
   def new
     @indicator = Indicator.new(model: nil, parent: nil)
+    @categories = Category.all.to_json
     render template: 'indicators/edit'
   end
 
@@ -34,6 +35,7 @@ class SystemIndicatorsController < AdminController
   end
 
   def edit
+    @categories = Category.all.to_json
     render template: 'indicators/edit'
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,7 +47,8 @@ module ApplicationHelper
   def reference_input(object, form, attr_info)
     select_values, selection, disabled =
       values_for_reference_dropdown(object, attr_info)
-    options = {prompt: 'Select element'}
+    options = (attr_info.options && attr_info.options.symbolize_keys) ||
+      {prompt: 'Select element'}
     html_options = {class: 'js-select', disabled: disabled}
     object_method = attr_info.ref_object_symbol + '_id'
     content_tag :div, class: "c-select -#{attr_info.size}" do

--- a/app/helpers/indicators_helper.rb
+++ b/app/helpers/indicators_helper.rb
@@ -12,7 +12,7 @@ module IndicatorsHelper
 
   def categories_for_select
     options_for_select(
-      Indicator.order(:category).distinct.pluck(:category)
+      Category.order(:name).pluck(:name, :id)
     )
   end
 
@@ -32,6 +32,30 @@ module IndicatorsHelper
         [i.alias, i.id]
       end
     [select_values, selection, action_name == 'fork']
+  end
+
+  def values_for_indicator_category_dropdown(indicator)
+    select_values = Category.
+      where('parent_id IS NULL').
+      select(:id, :name).
+      order(name: :asc).
+      pluck(:name, :id)
+
+    selection = indicator.category
+
+    [select_values, selection, false]
+  end
+
+  def values_for_indicator_subcategory_dropdown(indicator)
+    select_values = Category.
+      where('parent_id IS NOT NULL').
+      select(:id, :name).
+      order(name: :asc).
+      pluck(:name, :id)
+
+    selection = indicator.subcategory
+
+    [select_values, selection, false]
   end
 
   def destroy_confirmation_message(indicator)

--- a/app/helpers/indicators_helper.rb
+++ b/app/helpers/indicators_helper.rb
@@ -51,7 +51,9 @@ module IndicatorsHelper
       where('parent_id IS NOT NULL').
       select(:id, :name).
       order(name: :asc).
-      pluck(:name, :id)
+      pluck(:name, :stackable, :id).map do |name, stackable, id|
+        [stackable ? "#{name} (stackable)" : name, id]
+      end
 
     selection = indicator.subcategory
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,20 @@
 class Category < ApplicationRecord
-  belongs_to :parent, class_name: 'Category', foreign_key: 'parent_id'
+  belongs_to :parent, class_name: 'Category', foreign_key: 'parent_id', optional: true
   has_many :children, class_name: 'Category', foreign_key: 'parent_id'
+
+  def self.case_insensitive_find_or_create(attributes)
+    category = Category.where('lower(name) = lower(?)', attributes[:name])
+
+    if (attributes[:parent])
+      category = category.where(parent: attributes[:parent])
+    end
+
+    category = category.first
+
+    unless category
+      category = Category.new(attributes)
+    end
+
+    category
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,8 +5,12 @@ class Category < ApplicationRecord
   def self.case_insensitive_find_or_create(attributes)
     category = Category.where('lower(name) = lower(?)', attributes[:name])
 
-    if (attributes[:parent])
+    if attributes[:parent]
       category = category.where(parent: attributes[:parent])
+    end
+
+    if attributes[:stackable]
+      category = category.where(stackable: attributes[:stackable])
     end
 
     category = category.first

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,12 @@
 class Category < ApplicationRecord
+  validates :name, presence: true
+
   belongs_to :parent, class_name: 'Category', foreign_key: 'parent_id', optional: true
-  has_many :children, class_name: 'Category', foreign_key: 'parent_id'
+  has_many :subcategories, class_name: 'Category', foreign_key: 'parent_id'
+
+  accepts_nested_attributes_for :subcategories
+
+  ORDERS = %w[name parent stackable].freeze
 
   def self.case_insensitive_find_or_create(attributes)
     category = Category.where('lower(name) = lower(?)', attributes[:name])
@@ -20,5 +26,44 @@ class Category < ApplicationRecord
     end
 
     category
+  end
+
+  class << self
+    def fetch_all(options)
+      categories = Category.includes(:subcategories).where(parent_id: nil)
+      options.each do |filter|
+        categories = apply_filter(categories, options, filter[0], filter[1])
+      end
+      unless options['order_type'].present?
+        categories = categories.order(name: :asc)
+      end
+      categories
+    end
+
+    def apply_filter(categories, options, filter, value)
+      puts "a_f #{filter} #{value}"
+      case filter
+      when 'search'
+        categories.where(
+          'lower(name) LIKE :name',
+          name: "%#{value.downcase}%"
+        )
+      when 'order_type'
+        fetch_with_order(
+          categories,
+          value,
+          options['order_direction']
+        )
+      else
+        categories
+      end
+    end
+
+    def fetch_with_order(categories, order_type, order_direction)
+      order_direction = get_order_direction(order_direction)
+      order_type = get_order_type(ORDERS, order_type)
+
+      categories.order(order_type => order_direction, name: :asc)
+    end
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,4 @@
+class Category < ApplicationRecord
+  belongs_to :parent, class_name: 'Category', foreign_key: 'parent_id'
+  has_many :children, class_name: 'Category', foreign_key: 'parent_id'
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,8 +1,10 @@
 class Category < ApplicationRecord
   validates :name, presence: true
-  validate :parent_categories_cannot_be_stackable, :cannot_have_subcategory_as_parent
+  validate :parent_categories_cannot_be_stackable,
+           :cannot_have_subcategory_as_parent
 
-  belongs_to :parent, class_name: 'Category', foreign_key: 'parent_id', optional: true
+  belongs_to :parent, class_name: 'Category', foreign_key: 'parent_id',
+             optional: true
   has_many :subcategories, class_name: 'Category', foreign_key: 'parent_id'
 
   accepts_nested_attributes_for :subcategories
@@ -54,7 +56,6 @@ class Category < ApplicationRecord
     end
 
     def apply_filter(categories, options, filter, value)
-      puts "a_f #{filter} #{value}"
       case filter
       when 'search'
         categories.where(

--- a/app/models/concerns/alias_transformations.rb
+++ b/app/models/concerns/alias_transformations.rb
@@ -11,9 +11,6 @@ module AliasTransformations
 
     # ensure no trailing whitespace in attributes used for matching
     before_validation :strip_whitespace
-    before_validation :fix_category_capitalisation, if: proc { |i|
-      i.category.present?
-    }
 
     # update alias if system indicator
     # or team indicator with blank alias
@@ -21,13 +18,6 @@ module AliasTransformations
       i.parent_id.blank? && (i.model_id.blank? || i.alias.blank?)
     }
     before_save :update_category, if: proc { |i| i.parent.present? }
-
-    validates :category, presence: true, inclusion: {
-      in: Indicator.valid_categories,
-      message: 'must be one of ' +
-        Indicator.valid_categories.join(', '),
-      if: proc { |i| i.category.present? }
-    }
   end
 
   def copy_from_parent
@@ -39,15 +29,9 @@ module AliasTransformations
   end
 
   def strip_whitespace
-    self.category = category.try(:strip)
-    self.subcategory = subcategory.try(:strip)
     self.name = name.try(:strip)
     self.unit = unit.try(:strip)
     self.unit_of_entry = unit_of_entry.try(:strip)
-  end
-
-  def fix_category_capitalisation
-    self.category = Indicator.fix_category_capitalisation(category)
   end
 
   def update_alias
@@ -55,7 +39,7 @@ module AliasTransformations
   end
 
   def build_alias
-    [category, subcategory, name].join('|').chomp('|')
+    [category.name, subcategory&.name, name].join('|').chomp('|')
   end
 
   def update_category
@@ -74,7 +58,7 @@ module AliasTransformations
     end
 
     def slug_parts_to_hash(slug_parts)
-      slug_hash = {category: fix_category_capitalisation(slug_parts[0])}
+      slug_hash = {category: slug_parts[0]}
       if slug_parts.length >= 2
         slug_hash[:subcategory] = slug_parts[1].presence
         slug_hash[:name] = slug_parts[2].presence if slug_parts.length == 3
@@ -83,17 +67,7 @@ module AliasTransformations
     end
 
     def hash_to_slug(hash)
-      [hash[:category], hash[:subcategory], hash[:name]].join('|')
-    end
-
-    def valid_categories
-      Indicator.attribute_info(:category).options
-    end
-
-    def fix_category_capitalisation(category)
-      idx = valid_categories.map(&:downcase).
-        index(category.downcase)
-      idx && valid_categories[idx] || category
+      [hash[:category].name, hash[:subcategory].name, hash[:name]].join('|')
     end
   end
 end

--- a/app/models/concerns/alias_transformations.rb
+++ b/app/models/concerns/alias_transformations.rb
@@ -24,7 +24,6 @@ module AliasTransformations
     self.category = parent.category
     self.subcategory = parent.subcategory
     self.name = parent.name
-    self.stackable_subcategory = parent.stackable_subcategory
     self.unit = parent.unit
   end
 
@@ -46,7 +45,6 @@ module AliasTransformations
     self.category = parent.category
     self.subcategory = parent.subcategory
     self.name = parent.name
-    self.stackable_subcategory = parent.stackable_subcategory
   end
 
   class_methods do

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -15,6 +15,7 @@ class Indicator < ApplicationRecord
   has_many :time_series_values, dependent: :destroy
   belongs_to :model, optional: true
   belongs_to :category
+  belongs_to :subcategory, class_name: 'Category', optional: true
 
   validates :model, presence: true, if: proc { |i| i.parent.present? }
   validates :conversion_factor, presence: {

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -28,8 +28,10 @@ class Indicator < ApplicationRecord
   before_validation :ignore_blank_array_values
 
   pg_search_scope :search_for, against: [
-    :category, :subcategory, :name, :alias
-  ]
+    :name, :alias
+  ], associated_against: {
+    category: :name
+  }
 
   def self.model_variations(model)
     where(model_id: model.respond_to?(:id) ? model.id : model)

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -29,9 +29,7 @@ class Indicator < ApplicationRecord
 
   pg_search_scope :search_for, against: [
     :name, :alias
-  ], associated_against: {
-    category: :name
-  }
+  ]
 
   def self.model_variations(model)
     where(model_id: model.respond_to?(:id) ? model.id : model)

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -14,6 +14,7 @@ class Indicator < ApplicationRecord
            dependent: :nullify
   has_many :time_series_values, dependent: :destroy
   belongs_to :model, optional: true
+  belongs_to :category
 
   validates :model, presence: true, if: proc { |i| i.parent.present? }
   validates :conversion_factor, presence: {

--- a/app/modules/indicators_data.rb
+++ b/app/modules/indicators_data.rb
@@ -53,7 +53,7 @@ class IndicatorsData
   end
 
   def process_system_indicator(id_attributes, common_attributes, row_no)
-    id_attributes = indicator_attributes(id_attributes)
+    id_attributes, common_attributes = indicator_attributes(id_attributes, common_attributes)
     if @user.cannot?(:create, Indicator.new(model_id: nil))
       message = 'Access denied to manage core indicators.'
       suggestion = 'ESP admins curate core indicators. Please add a team \
@@ -86,7 +86,7 @@ indicator instead.'
     id_attributes, common_attributes, model_slug, row_no
   )
 
-    id_attributes = indicator_attributes(id_attributes)
+    id_attributes, common_attributes = indicator_attributes(id_attributes, common_attributes)
     if @user.cannot?(:create, Indicator.new(model_id: @model.id))
       message = "Access denied to manage team indicators \
 (#{@model.abbreviation})."
@@ -141,19 +141,24 @@ indicator instead.'
     nil
   end
 
-  def indicator_attributes(attributes)
+  def indicator_attributes(id_attributes, common_attributes)
     category = Category.case_insensitive_find_or_create(
-      name: attributes[:category]
+      name: id_attributes[:category]
     )
 
     subcategory = Category.case_insensitive_find_or_create(
-      name: attributes[:subcategory],
+      name: id_attributes[:subcategory],
+      stackable: common_attributes[:stackable_subcategory],
       parent: category
     )
 
-    attributes.
-      except(:category, :subcategory).
-      merge(category: category, subcategory: subcategory)
+    [
+      id_attributes.
+        except(:category, :subcategory).
+        merge(category: category, subcategory: subcategory),
+      common_attributes.
+        except(:stackable_subcategory)
+    ]
   end
 
 end

--- a/app/modules/indicators_data.rb
+++ b/app/modules/indicators_data.rb
@@ -53,7 +53,8 @@ class IndicatorsData
   end
 
   def process_system_indicator(id_attributes, common_attributes, row_no)
-    id_attributes, common_attributes = indicator_attributes(id_attributes, common_attributes)
+    id_attributes, common_attributes =
+        indicator_attributes(id_attributes, common_attributes)
     if @user.cannot?(:create, Indicator.new(model_id: nil))
       message = 'Access denied to manage core indicators.'
       suggestion = 'ESP admins curate core indicators. Please add a team \
@@ -85,8 +86,9 @@ indicator instead.'
   def process_team_variation(
     id_attributes, common_attributes, model_slug, row_no
   )
+    id_attributes, common_attributes =
+      indicator_attributes(id_attributes, common_attributes)
 
-    id_attributes, common_attributes = indicator_attributes(id_attributes, common_attributes)
     if @user.cannot?(:create, Indicator.new(model_id: @model.id))
       message = "Access denied to manage team indicators \
 (#{@model.abbreviation})."
@@ -160,5 +162,4 @@ indicator instead.'
         except(:stackable_subcategory)
     ]
   end
-
 end

--- a/app/modules/indicators_data.rb
+++ b/app/modules/indicators_data.rb
@@ -53,6 +53,7 @@ class IndicatorsData
   end
 
   def process_system_indicator(id_attributes, common_attributes, row_no)
+    id_attributes = indicator_attributes(id_attributes)
     if @user.cannot?(:create, Indicator.new(model_id: nil))
       message = 'Access denied to manage core indicators.'
       suggestion = 'ESP admins curate core indicators. Please add a team \
@@ -84,6 +85,8 @@ indicator instead.'
   def process_team_variation(
     id_attributes, common_attributes, model_slug, row_no
   )
+
+    id_attributes = indicator_attributes(id_attributes)
     if @user.cannot?(:create, Indicator.new(model_id: @model.id))
       message = "Access denied to manage team indicators \
 (#{@model.abbreviation})."
@@ -137,4 +140,20 @@ indicator instead.'
     process_other_errors(row_no, indicator.errors)
     nil
   end
+
+  def indicator_attributes(attributes)
+    category = Category.case_insensitive_find_or_create(
+      name: attributes[:category]
+    )
+
+    subcategory = Category.case_insensitive_find_or_create(
+      name: attributes[:subcategory],
+      parent: category
+    )
+
+    attributes.
+      except(:category, :subcategory).
+      merge(category: category, subcategory: subcategory)
+  end
+
 end

--- a/app/serializers/api/v1/category_serializer.rb
+++ b/app/serializers/api/v1/category_serializer.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class CategorySerializer < ActiveModel::Serializer
+      attribute :id
+      attribute :name
+      attribute :parent_id
+    end
+  end
+end
+

--- a/app/serializers/api/v1/category_serializer.rb
+++ b/app/serializers/api/v1/category_serializer.rb
@@ -3,7 +3,7 @@ module Api
     class CategorySerializer < ActiveModel::Serializer
       attribute :id
       attribute :name
-      attribute :parent_id
+      attribute :parent_id, if: -> { object.parent_id }
     end
   end
 end

--- a/app/serializers/api/v1/indicator_serializer.rb
+++ b/app/serializers/api/v1/indicator_serializer.rb
@@ -2,8 +2,6 @@ module Api
   module V1
     class IndicatorSerializer < ActiveModel::Serializer
       attribute :id
-      attribute :category
-      attribute :subcategory
       attribute :name
       attribute :definition
       attribute :unit
@@ -16,17 +14,20 @@ module Api
       attribute :model_id
       attribute :parent_id
 
+      belongs_to :category
+      belongs_to :subcategory
+
       def category
         if object.category.parent
-          object.category.parent.name
+          object.category.parent
         else
-          object.category.name
+          object.category
         end
       end
 
       def subcategory
         if object.category.parent
-          object.category.name
+          object.category
         end
       end
     end

--- a/app/serializers/api/v1/indicator_serializer.rb
+++ b/app/serializers/api/v1/indicator_serializer.rb
@@ -3,6 +3,7 @@ module Api
     class IndicatorSerializer < ActiveModel::Serializer
       attribute :id
       attribute :category
+      attribute :subcategory
       attribute :name
       attribute :definition
       attribute :unit
@@ -14,6 +15,20 @@ module Api
       attribute :auto_generated
       attribute :model_id
       attribute :parent_id
+
+      def category
+        if object.category.parent
+          object.category.parent.name
+        else
+          object.category.name
+        end
+      end
+
+      def subcategory
+        if object.category.parent
+          object.category.name
+        end
+      end
     end
   end
 end

--- a/app/serializers/api/v1/indicator_serializer.rb
+++ b/app/serializers/api/v1/indicator_serializer.rb
@@ -16,20 +16,6 @@ module Api
 
       belongs_to :category
       belongs_to :subcategory
-
-      def category
-        if object.category.parent
-          object.category.parent
-        else
-          object.category
-        end
-      end
-
-      def subcategory
-        if object.category.parent
-          object.category
-        end
-      end
     end
   end
 end

--- a/app/serializers/api/v1/indicator_serializer.rb
+++ b/app/serializers/api/v1/indicator_serializer.rb
@@ -5,8 +5,6 @@ module Api
       attribute :name
       attribute :definition
       attribute :unit
-      attribute :subcategory
-      attribute :stackable_subcategory
       attribute :unit_of_entry
       attribute :conversion_factor
       attribute :alias

--- a/app/services/filter_indicators.rb
+++ b/app/services/filter_indicators.rb
@@ -59,6 +59,7 @@ class FilterIndicators
       references(:category, :subcategory)
 
     ids = category.split(',').map(&:to_i)
+
     query.where('categories.id IN (?) OR subcategories_indicators.id IN (?)', ids, ids)
   end
 

--- a/app/services/filter_indicators.rb
+++ b/app/services/filter_indicators.rb
@@ -54,10 +54,12 @@ class FilterIndicators
   def category_scope
     return indicators if category.blank?
 
-    indicators.
-      includes(:category).
-      references(:category).
-      where('categories.name IN (?)', category.split(','))
+    query = indicators.
+      includes(:category, :subcategory).
+      references(:category, :subcategory)
+
+    ids = category.split(',').map(&:to_i)
+    query.where('categories.id IN (?) OR subcategories_indicators.id IN (?)', ids, ids)
   end
 
   def model_name_order_clause(direction)

--- a/app/services/filter_indicators.rb
+++ b/app/services/filter_indicators.rb
@@ -32,7 +32,9 @@ class FilterIndicators
     return indicators if order_type.blank?
 
     order_clause = send("#{order_type}_order_clause", order_direction)
-    indicators.order(order_clause)
+    indicators.
+      joins(:category, :subcategory).
+      order(order_clause)
   end
 
   def type_scope
@@ -52,7 +54,10 @@ class FilterIndicators
   def category_scope
     return indicators if category.blank?
 
-    indicators.where('indicators.category IN (?)', category.split(','))
+    indicators.
+      includes(:category).
+      references(:category).
+      where('categories.name IN (?)', category.split(','))
   end
 
   def model_name_order_clause(direction)
@@ -67,8 +72,8 @@ class FilterIndicators
   end
 
   def esp_name_order_clause(direction)
-    %w(category subcategory name).map do |column|
-      ["indicators.#{column}", direction].join(' ')
+    %w(categories.name subcategories_indicators.name indicators.name).map do |column|
+      [column, direction].join(' ')
     end.join(', ')
   end
 

--- a/app/views/admin/home.html.erb
+++ b/app/views/admin/home.html.erb
@@ -22,9 +22,9 @@
     </div>
     <div class="small-6 columns">
       <%= render 'shared/components/c_model_overview_card',
-                 title: 'Countries',
+                 title: 'countries',
                  values: @locations,
-                 button_text: 'Manage countries',
+                 button_text: 'manage countries',
                  button_url: locations_url
       %>
     </div>
@@ -34,6 +34,14 @@
                  values: @indicators,
                  button_text: 'Manage indicators',
                  button_url: indicators_url
+      %>
+    </div>
+    <div class="small-6 columns">
+      <%= render 'shared/components/c_model_overview_card',
+                 title: 'Categories',
+                 values: @categories,
+                 button_text: 'Manage categories',
+                 button_url: categories_url
       %>
     </div>
   </div>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,0 +1,125 @@
+<%
+  form_blocks = [
+    ['Category Info'],
+    ['Subcategories']
+  ]
+%>
+<%= render 'shared/components/c_landing_header', no_nav: true %>
+
+<div class="l-categories-edit">
+  <div class="row l-categories-edit__fields">
+    <div class="small-3 columns">
+      <%= render 'shared/components/form/c_form_vertical_nav', form_blocks: form_blocks %>
+    </div>
+    <div class="small-9 columns">
+      <%= form_for @category do |f| %>
+        <div class="row">
+          <div class="small-12 columns">
+            <div class="row align-right">
+              <div class="small-2 columns">
+                <%= link_to categories_url, class: 'l-categories-edit__form-action' do %>
+                  <%= render 'shared/components/c_flying_button' %>
+                <% end %>
+              </div>
+              <div class="small-2 columns">
+                <%= f.submit 'Save', class: 'c-button' %>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="small-12 columns">
+            <div class="c-form" data-block-key="<%= Digest::MD5.hexdigest('Category Info') %>">
+              <div class="c-item-header -color-2">
+                <div class="f-ff1-xs">Category Info</div>
+              </div>
+              <div class="c-form-items">
+                <div class="c-form-item -highlighted <% if @category.errors.messages[:name].present? %>-error<% end %>">
+                  <%= f.label :name, 'Category name', class: 'f-ff1-m' %>
+                  <%= f.text_field :name, class: 'c-input-text -large js-form-input' %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <% if @category.persisted? %>
+          <div class="row">
+            <div class="small-12 columns">
+              <div class="c-form l-categories-edit__form-subcategories" data-block-key="<%= Digest::MD5.hexdigest('Subcategories') %>">
+                <div class="c-item-header -color-2">
+                  <div class="f-ff1-xs">Subcategories</div>
+                </div>
+                <div class="c-form-items">
+                  <div class="l-categories-edit__subcategory">
+                    <%= f.fields_for :subcategories do |ff| %>
+                      <li class="row">
+                        <div class="small-8 columns">
+                          <%= ff.text_field :name, class: 'c-input-text js-form-input', placeholder: 'Name' %>
+                        </div>
+                        <div class="small-2 columns">
+                          <div class="c-checkbox">
+                            <%= ff.check_box :stackable %>
+                            <%= ff.label :stackable do %>
+                              <div class="c-checkbox__box">
+                                <svg class="icon icon-checkbox-off"><use xlink:href="#icon-checkbox-off"></use></svg>
+                                <svg class="icon icon-checkbox-on"><use xlink:href="#icon-checkbox-on"></use></svg>
+                              </div>
+                              <div class="f-ff1-s">Stackable</div>
+                            <% end %>
+                          </div>
+                        </div>
+                        <div class="small-2 columns">
+                          <%= link_to category_subcategory_url(@category, ff.object),
+                            method: :delete,
+                            data: { confirm: 'Are you sure?' } do
+                          %>
+                            <div class="c-remove-button">
+                              <svg class="icon"><use xlink:href="#icon-delete"></use></svg>
+                              <div class="f-ff1-s">Delete</div>
+                            </div>
+                          <% end %>
+                        </div>
+                      </li>
+                    <% end %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+      <% if @category.persisted? %>
+        <div class="c-form l-categories-edit__form-add-subcategories">
+          <%= form_tag(category_subcategories_url(@category)) do %>
+            <div class="c-form-items">
+              <div class="c-form-item l-categories-edit__add-subcategory row">
+                <div class="small-8 columns">
+                  <%= text_field_tag 'category[name]',
+                                     nil,
+                                     placeholder: 'Enter subcategory name',
+                                     class: 'c-input-text js-form-input' %>
+                </div>
+                <div class="small-2 columns">
+                  <div class="c-checkbox">
+                    <%= check_box_tag 'category[stackable]' %>
+                    <%= label_tag 'category[stackable]' do %>
+                      <div class="c-checkbox__box">
+                        <svg class="icon icon-checkbox-off"><use xlink:href="#icon-checkbox-off"></use></svg>
+                        <svg class="icon icon-checkbox-on"><use xlink:href="#icon-checkbox-on"></use></svg>
+                      </div>
+                      <div class="f-ff1-s">Stackable</div>
+                    <% end %>
+                  </div>
+                </div>
+                <div class="small-2 columns">
+                  <%= submit_tag 'Add', class: 'c-button' %>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,86 @@
+<%= render 'shared/components/c_landing_header', no_nav: true %>
+<div class="l-categories">
+  <div class="row">
+    <div class="small-6 columns">
+      <div class="f-ff3-m-bold l-categories__title">Category<span>(<%= @categories.length %>)</span></div>
+    </div>
+    <div class="small-3 columns">
+      <div class="c-form-item">
+        <%= render 'shared/components/form/c_input_search.html',
+                   placeholder: 'Filter by name',
+                   js_class: 'js-table-filter',
+                   data: {
+                     'filter-type' => 'search',
+                     'filter-key' => 'search'
+                   } %>
+      </div>
+    </div>
+    <% if current_user.can?(:create, Category) %>
+      <div class="small-3 columns">
+        <%= link_to new_category_path do %>
+          <div class="c-button">
+            <span>Add new category</span>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  <div class="l-categories__table-shorts js-table-filter" data-filter-type="order">
+    <div class="row">
+      <div class="small-8 columns">
+        <%= render 'shared/components/c_order_filter_button',
+                   text: 'Name',
+                   column_key: 'name' %>
+      </div>
+      <div class="small-2 columns">
+        <%= render 'shared/components/c_order_filter_button',
+                   text: 'Subcategory Count',
+                   column_key: 'subcategories' %>
+      </div>
+      <div class="small-1 columns">
+      </div>
+    </div>
+  </div>
+  <% @categories.each do |category| %>
+    <div class="c-table-list-item -center">
+      <div class="row">
+        <div class="small-8 columns">
+          <div class="c-table-list-item__text f-ff1-m-bold"><%= category.name %></div>
+        </div>
+        <div class="small-2 columns">
+          <div class="c-table-list-item__text f-ff1-m-bold"><%= category.subcategories.length %></div>
+        </div>
+        <div class="small-1 columns">
+          <div class="c-table-list-item__text f-ff1-m">
+            <% if category.stackable? %>
+              <svg class="icon icon-check"><use xlink:href="#icon-check"></use></svg>
+            <% else %>
+              <div class="icon icon-cancel"></div>
+            <% end %>
+          </div>
+        </div>
+        <div class="small-1 columns">
+          <div class="c-table-list-item__actions">
+            <% if current_user.can?(:destroy, category) %>
+              <%= link_to category_path(category), method: :delete, data: { confirm: 'Are you sure?' } do %>
+                <div class="c-delete-button">
+                  <svg class="icon"><use xlink:href="#icon-delete"></use></svg>
+                </div>
+              <% end %>
+            <% end %>
+            <% if current_user.can?(:update, category) %>
+              <%= link_to edit_category_path(category) do %>
+                <div class="c-edit-button">
+                  <div class="c-edit-button__bubble">
+                    <svg class="icon"><use xlink:href="#icon-edit"></use></svg>
+                  </div>
+                  <div class="f-ff1-s">Edit</div>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/indicators/edit.html.erb
+++ b/app/views/indicators/edit.html.erb
@@ -1,6 +1,10 @@
 <%= render 'shared/components/c_landing_header',
   title: @indicator.name %>
 
+<script>
+  App.Data.categories = <%= raw(@categories) %>;
+</script>
+
 <%= form_for [@model, @indicator] do |f| %>
   <div class="l-indicator-edit">
     <div class="row">

--- a/app/views/indicators/show.html.erb
+++ b/app/views/indicators/show.html.erb
@@ -28,11 +28,11 @@
     <div class="row">
       <div class="small-2 columns">
         <div class="f-ff1-m-bold">Category</div>
-        <div class="f-ff1-m l-indicators-overview__data"><%= @indicator.category %></div>
+        <div class="f-ff1-m l-indicators-overview__data"><%= @indicator.category.name %></div>
       </div>
       <div class="small-2 columns">
         <div class="f-ff1-m-bold">Subcategory</div>
-        <div class="f-ff1-m l-indicators-overview__data"><%= @indicator.subcategory %></div>
+        <div class="f-ff1-m l-indicators-overview__data"><%= @indicator.subcategory&.name %></div>
       </div>
       <div class="small-1 columns">
         <div class="f-ff1-m-bold">ESP Unit</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,10 +166,10 @@ en:
     alias:
       name: "Model Indicator Name"
       definition: "Alias for a core indicator (only applicable for derived indicators)"
-    category:
+    category_id:
       name: "Category"
       definition: "Which category does it belong to? Categories are fixed in the system and the options are: Emissions, Climate and Health Impacts, Population and Economy, Energy, Electricty, Industry, Buildings, Transportation, Agriculture Land Use and Forestry, Policy, Technology, Financial"
-    subcategory:
+    subcategory_id:
       name: "Subcategory"
       definition: "What sub-category does the indicator belong to? New sub-categories can be added"
     stackable_subcategory:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,11 @@ Rails.application.routes.draw do
 
   resources :locations, only: [:index, :new, :create, :edit, :update, :destroy]
 
+  resources :categories, only: [:index, :new, :create, :edit, :update, :destroy] do
+    resources :subcategories, only: [:create, :destroy],
+              controller: 'category_subcategories'
+  end
+
   # Rails routes are matched in the order they are specified
   root to: "admin#home",
     constraints: lambda { |request| request.env['warden'].user.try(:admin?) },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
       resources :indicators, only: [:index, :show]
       resources :time_series_values, only: [:index]
       resources :locations, only: [:index]
+      resources :categories, only: [:index]
     end
   end
 end

--- a/db/indicators_metadata.yml
+++ b/db/indicators_metadata.yml
@@ -11,6 +11,8 @@
 - name: :subcategory_id
   reference: 'subcategory.id'
   size: 'large'
+  options:
+    include_blank: 'None'
 - name: :unit
   picklist: true
   size: 'small'

--- a/db/indicators_metadata.yml
+++ b/db/indicators_metadata.yml
@@ -11,8 +11,6 @@
 - name: :subcategory_id
   reference: 'subcategory.id'
   size: 'large'
-- name: :stackable_subcategory
-  checkbox: true
 - name: :unit
   picklist: true
   size: 'small'

--- a/db/indicators_metadata.yml
+++ b/db/indicators_metadata.yml
@@ -5,17 +5,12 @@
   size: 'large'
 - name: :name
   size: 'small'
-- name: :category
-  picklist: true
+- name: :category_id
+  reference: 'category.id'
   size: 'large'
-  options: [
-    'Emissions', 'Climate and Health Impacts', 'Population and Economy',
-    'Energy', 'Electricity', 'Industry', 'Buildings', 'Transportation',
-    'Agriculture, Land Use and Forestry', 'Policy', 'Technology', 'Financial'
-  ]
-- name: :subcategory
-  picklist: true
-  size: 'small'
+- name: :subcategory_id
+  reference: 'subcategory.id'
+  size: 'large'
 - name: :stackable_subcategory
   checkbox: true
 - name: :unit

--- a/db/migrate/20170728144124_add_attachment_csv_file_to_csv_uploads.rb
+++ b/db/migrate/20170728144124_add_attachment_csv_file_to_csv_uploads.rb
@@ -1,4 +1,4 @@
-class AddAttachmentCsvFileToCsvUploads < ActiveRecord::Migration
+class AddAttachmentCsvFileToCsvUploads < ActiveRecord::Migration[5.1]
   def self.up
     change_table :csv_uploads do |t|
       t.attachment :data

--- a/db/migrate/20171113125155_create_categories.rb
+++ b/db/migrate/20171113125155_create_categories.rb
@@ -1,0 +1,11 @@
+class CreateCategories < ActiveRecord::Migration[5.1]
+  def change
+    create_table :categories do |t|
+      t.text :name
+      t.references :parent, foreign_key: {
+        to_table: :categories,
+        on_delete: :cascade
+      }
+    end
+  end
+end

--- a/db/migrate/20171113125155_create_categories.rb
+++ b/db/migrate/20171113125155_create_categories.rb
@@ -2,6 +2,7 @@ class CreateCategories < ActiveRecord::Migration[5.1]
   def change
     create_table :categories do |t|
       t.text :name
+      t.boolean :stackable
       t.references :parent, foreign_key: {
         to_table: :categories,
         on_delete: :cascade

--- a/db/migrate/20171113125206_modify_indicators.rb
+++ b/db/migrate/20171113125206_modify_indicators.rb
@@ -1,0 +1,72 @@
+class ModifyIndicators < ActiveRecord::Migration[5.1]
+  class Category < ApplicationRecord
+    belongs_to :parent, class_name: 'Category', foreign_key: 'parent_id', optional: true
+    has_many :children, class_name: 'Category', foreign_key: 'parent_id'
+  end
+
+  class Indicator < ApplicationRecord
+    belongs_to :the_category, class_name: 'Category', foreign_key: 'category_id'
+  end
+
+  def change
+    add_reference :indicators, :category, foreign_key: {
+      to_table: :categories
+    }
+    migrate_data
+    remove_column :indicators, :category, :string
+    remove_column :indicators, :subcategory, :string
+  end
+
+  private
+
+  def migrate_data
+    reversible do |dir|
+      dir.up do
+        say_with_time 'migrate_data' do
+          migrate_data_up
+        end
+      end
+
+      dir.down do
+        say_with_time 'migrate_data' do
+          migrate_data_down
+        end
+      end
+    end
+  end
+
+  def migrate_data_up
+    Indicator.all.each do |ind|
+      unless ind[:category].blank?
+        category = Category.find_or_create_by!(
+          name: ind[:category]
+        )
+
+        unless ind[:subcategory].blank?
+          subcategory = Category.find_or_create_by!(
+            name: ind[:subcategory],
+            parent: category
+          )
+        end
+      end
+
+      unless category.nil? && subcategory.nil?
+        ind.category_id = (subcategory || category).id
+        ind.save!
+      end
+    end
+  end
+
+  def migrate_data_down
+    Indicator.includes(the_category: :parent).all.each do |ind|
+      if ind.the_category && ind.the_category.parent
+        ind.category = ind.the_category.parent.name
+        ind.subcategory = ind.the_category.name
+        ind.save!
+      elsif ind.the_category
+        ind.category = ind.the_category.name
+        ind.save!
+      end
+    end
+  end
+end

--- a/db/migrate/20171113125206_modify_indicators.rb
+++ b/db/migrate/20171113125206_modify_indicators.rb
@@ -19,6 +19,7 @@ class ModifyIndicators < ActiveRecord::Migration[5.1]
     migrate_data
     remove_column :indicators, :category, :string
     remove_column :indicators, :subcategory, :string
+    remove_column :indicators, :stackable_subcategory, :boolean
   end
 
   private
@@ -49,6 +50,7 @@ class ModifyIndicators < ActiveRecord::Migration[5.1]
         unless ind[:subcategory].blank?
           subcategory = Category.find_or_create_by!(
             name: ind[:subcategory],
+            stackable: ind[:stackable_subcategory],
             parent: category
           )
         end
@@ -66,6 +68,7 @@ class ModifyIndicators < ActiveRecord::Migration[5.1]
     Indicator.includes(the_category: :parent).all.each do |ind|
       ind.category = ind.the_category.name if ind.the_category
       ind.subcategory = ind.the_subcategory.name if ind.the_subcategory
+      ind.stackable_subcategory = ind.the_subcategory.stackable if ind.the_subcategory
       ind.save! if (ind.the_category || ind.the_subcategory)
     end
   end

--- a/db/migrate/20171113125206_modify_indicators.rb
+++ b/db/migrate/20171113125206_modify_indicators.rb
@@ -50,7 +50,7 @@ class ModifyIndicators < ActiveRecord::Migration[5.1]
         unless ind[:subcategory].blank?
           subcategory = Category.find_or_create_by!(
             name: ind[:subcategory],
-            stackable: ind[:stackable_subcategory],
+            stackable: !!ind[:stackable_subcategory],
             parent: category
           )
         end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,10 +55,12 @@ ActiveRecord::Schema.define(version: 20171120094334) do
     t.boolean "auto_generated", default: false
     t.integer "model_id"
     t.bigint "category_id"
+    t.bigint "subcategory_id"
     t.index ["category_id"], name: "index_indicators_on_category_id"
     t.index ["model_id", "parent_id", "alias"], name: "index_indicators_on_model_id_and_parent_id_and_alias", unique: true
     t.index ["model_id"], name: "index_indicators_on_model_id"
     t.index ["parent_id"], name: "index_indicators_on_parent_id"
+    t.index ["subcategory_id"], name: "index_indicators_on_subcategory_id"
   end
 
   create_table "locations", id: :serial, force: :cascade do |t|
@@ -220,6 +222,7 @@ ActiveRecord::Schema.define(version: 20171120094334) do
   add_foreign_key "csv_uploads", "models", on_delete: :cascade
   add_foreign_key "csv_uploads", "users", on_delete: :cascade
   add_foreign_key "indicators", "categories"
+  add_foreign_key "indicators", "categories", column: "subcategory_id"
   add_foreign_key "indicators", "indicators", column: "parent_id"
   add_foreign_key "indicators", "models"
   add_foreign_key "models", "teams"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20171120094334) do
 
   create_table "categories", force: :cascade do |t|
     t.text "name"
+    t.boolean "stackable"
     t.bigint "parent_id"
     t.index ["parent_id"], name: "index_categories_on_parent_id"
   end
@@ -47,7 +48,6 @@ ActiveRecord::Schema.define(version: 20171120094334) do
     t.text "unit"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "stackable_subcategory", default: false
     t.text "unit_of_entry"
     t.decimal "conversion_factor"
     t.integer "parent_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,12 @@ ActiveRecord::Schema.define(version: 20171120094334) do
   enable_extension "plpgsql"
   enable_extension "tablefunc"
 
+  create_table "categories", force: :cascade do |t|
+    t.text "name"
+    t.bigint "parent_id"
+    t.index ["parent_id"], name: "index_categories_on_parent_id"
+  end
+
   create_table "csv_uploads", id: :serial, force: :cascade do |t|
     t.text "job_id"
     t.integer "user_id", null: false
@@ -36,13 +42,11 @@ ActiveRecord::Schema.define(version: 20171120094334) do
   end
 
   create_table "indicators", id: :serial, force: :cascade do |t|
-    t.text "category", null: false
     t.text "name"
     t.text "definition"
     t.text "unit"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "subcategory"
     t.boolean "stackable_subcategory", default: false
     t.text "unit_of_entry"
     t.decimal "conversion_factor"
@@ -50,6 +54,8 @@ ActiveRecord::Schema.define(version: 20171120094334) do
     t.text "alias"
     t.boolean "auto_generated", default: false
     t.integer "model_id"
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_indicators_on_category_id"
     t.index ["model_id", "parent_id", "alias"], name: "index_indicators_on_model_id_and_parent_id_and_alias", unique: true
     t.index ["model_id"], name: "index_indicators_on_model_id"
     t.index ["parent_id"], name: "index_indicators_on_parent_id"
@@ -210,8 +216,10 @@ ActiveRecord::Schema.define(version: 20171120094334) do
     t.index ["team_id"], name: "index_users_on_team_id"
   end
 
+  add_foreign_key "categories", "categories", column: "parent_id", on_delete: :cascade
   add_foreign_key "csv_uploads", "models", on_delete: :cascade
   add_foreign_key "csv_uploads", "users", on_delete: :cascade
+  add_foreign_key "indicators", "categories"
   add_foreign_key "indicators", "indicators", column: "parent_id"
   add_foreign_key "indicators", "models"
   add_foreign_key "models", "teams"

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe CategoriesController, type: :controller do
+  let(:some_categories) {
+    create_list(:category, 10)
+  }
+
+  context 'when admin' do
+    login_admin
+
+    describe 'GET index' do
+      it 'renders index' do
+        get :index
+        expect(response).to render_template(:index)
+      end
+    end
+
+    describe 'GET new' do
+      it 'renders new' do
+        get :new
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    describe 'GET edit' do
+      it 'renders edit' do
+        get :edit, params: {id: some_categories[0].id}
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    describe 'POST create' do
+      it 'redirects to category when successful' do
+        post :create, params: {
+          category: {name: 'Edited Name'}
+        }
+        expect(response).to redirect_to(edit_category_url(assigns(:category)))
+      end
+
+      it 'renders edit when validation errors present' do
+        post :create, params: {
+          category: {name: nil}
+        }
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    describe 'PUT update' do
+      it 'redirects to category when successful' do
+        put :update, params: {
+          id: some_categories[0].id,
+          category: {name: 'Edited Name'}
+        }
+        expect(response).to redirect_to(edit_category_url(assigns(:category)))
+      end
+
+      it 'renders edit when validation errors present' do
+        put :update, params: {
+          id: some_categories[0].id,
+          category: {name: nil}
+        }
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe IndicatorsController, type: :controller do
     login_admin
     let(:team_model) { create(:model) }
     let(:some_model) { create(:model) }
+    let(:some_category) { create(:category, name: 'Buildings') }
+    let(:another_category) { create(:category, name: 'Transportation') }
     let!(:team_indicator) { create(:indicator, model: team_model) }
     let!(:some_indicator) { create(:indicator, model: some_model) }
     let!(:master_indicator) { create(:indicator, model: nil) }
@@ -38,7 +40,7 @@ RSpec.describe IndicatorsController, type: :controller do
     describe 'POST create' do
       it 'redirects to own team\'s indicator when successful' do
         post :create, params: {
-          model_id: team_model.id, indicator: {category: ['Buildings']}
+          model_id: team_model.id, indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(
           model_indicator_url(team_model, assigns(:indicator))
@@ -47,7 +49,7 @@ RSpec.describe IndicatorsController, type: :controller do
 
       it 'redirects to other team\'s indicator when successful' do
         post :create, params: {
-          model_id: some_model.id, indicator: {category: ['Buildings']}
+          model_id: some_model.id, indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(
           model_indicator_url(some_model, assigns(:indicator))
@@ -90,7 +92,7 @@ RSpec.describe IndicatorsController, type: :controller do
         put :update, params: {
           model_id: team_model.id,
           id: team_indicator.id,
-          indicator: {category: ['Buildings']}
+          indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(
           model_indicator_url(team_model, team_indicator)
@@ -101,7 +103,7 @@ RSpec.describe IndicatorsController, type: :controller do
         put :update, params: {
           model_id: some_model.id,
           id: some_indicator.id,
-          indicator: {category: ['Buildings']}
+          indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(
           model_indicator_url(some_model, some_indicator)
@@ -113,7 +115,7 @@ RSpec.describe IndicatorsController, type: :controller do
           put :update, params: {
             model_id: team_model.id,
             id: master_indicator.id,
-            indicator: {category: ['Buildings']}
+            indicator: {category_id: some_category.id}
           }
         }.not_to change(team_model.indicators, :count)
       end
@@ -164,6 +166,8 @@ RSpec.describe IndicatorsController, type: :controller do
     login_user
     let(:user_team) { @user.team }
     let(:some_team) { create(:team) }
+    let(:some_category) { create(:category, name: 'Buildings') }
+    let(:another_category) { create(:category, name: 'Transportation') }
     let!(:team_model) { create(:model, team: user_team) }
     let!(:some_model) { create(:model, team: some_team) }
     let(:team_indicator) { create(:indicator, model: team_model) }
@@ -205,14 +209,14 @@ RSpec.describe IndicatorsController, type: :controller do
     describe 'POST create' do
       it 'renders edit when validation errors present' do
         post :create, params: {
-          model_id: team_model.id, indicator: {category: [nil]}
+          model_id: team_model.id, indicator: {category_id: nil}
         }
         expect(response).to render_template(:edit)
       end
 
       it 'redirects to indicator when successful' do
         post :create, params: {
-          model_id: team_model.id, indicator: {category: ['Buildings']}
+          model_id: team_model.id, indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(
           model_indicator_url(team_model, assigns(:indicator))
@@ -234,7 +238,7 @@ RSpec.describe IndicatorsController, type: :controller do
 
       it 'prevents unauthorized access' do
         post :create, params: {
-          model_id: some_model.id, indicator: {category: ['Buildings']}
+          model_id: some_model.id, indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(root_url)
         expect(flash[:alert]).to match(/You are not authorized/)
@@ -246,7 +250,7 @@ RSpec.describe IndicatorsController, type: :controller do
           expect {
             post :create, params: {
               model_id: team_model.id, indicator: {
-                parent_id: some_indicator.id, category: ['Transportation'],
+                parent_id: some_indicator.id, category_id: another_category.id,
                 unit: ['km']
               }
             }
@@ -257,7 +261,7 @@ RSpec.describe IndicatorsController, type: :controller do
           expect {
             post :create, params: {
               model_id: team_model.id, indicator: {
-                parent_id: some_indicator.id, category: ['Transportation'],
+                parent_id: some_indicator.id, category_id: another_category.id,
                 unit_of_entry: ['m']
               }
             }
@@ -267,7 +271,7 @@ RSpec.describe IndicatorsController, type: :controller do
         it 'links old team indicator to new system indicator' do
           post :create, params: {
             model_id: team_model.id, indicator: {
-              parent_id: some_indicator.id, category: ['Transportation'],
+              parent_id: some_indicator.id, category_id: another_category.id,
               unit: ['km']
             }
           }
@@ -319,7 +323,7 @@ RSpec.describe IndicatorsController, type: :controller do
         put :update, params: {
           model_id: team_model.id,
           id: team_indicator.id,
-          indicator: {category: [nil]}
+          indicator: {category_id: nil}
         }
         expect(response).to render_template(:edit)
       end
@@ -328,7 +332,7 @@ RSpec.describe IndicatorsController, type: :controller do
         put :update, params: {
           model_id: team_model.id,
           id: team_indicator.id,
-          indicator: {category: ['Buildings']}
+          indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(
           model_indicator_url(team_model, team_indicator)
@@ -339,7 +343,7 @@ RSpec.describe IndicatorsController, type: :controller do
         put :update, params: {
           model_id: some_model.id,
           id: some_indicator.id,
-          indicator: {category: ['Buildings']}
+          indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(root_url)
         expect(flash[:alert]).to match(/You are not authorized/)

--- a/spec/controllers/system_indicators_controller_spec.rb
+++ b/spec/controllers/system_indicators_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe SystemIndicatorsController, type: :controller do
     login_admin
     let(:team_model) { create(:model) }
     let(:some_model) { create(:model) }
+    let(:some_category) { create(:category, name: 'Buildings') }
     let!(:team_indicator) { create(:indicator, model: team_model) }
     let!(:some_indicator) { create(:indicator, model: some_model) }
     let!(:master_indicator) { create(:indicator, model: nil) }
@@ -27,7 +28,7 @@ RSpec.describe SystemIndicatorsController, type: :controller do
 
     describe 'POST create' do
       it 'redirects to indicator when successful' do
-        post :create, params: {indicator: {category: ['Buildings']}}
+        post :create, params: {indicator: {category_id: some_category.id}}
         expect(response).to redirect_to(
           indicator_url(assigns(:indicator))
         )
@@ -45,7 +46,7 @@ RSpec.describe SystemIndicatorsController, type: :controller do
       it 'redirects to indicator when successful' do
         put :update, params: {
           id: team_indicator.id,
-          indicator: {category: ['Buildings']}
+          indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(
           indicator_url(team_indicator)
@@ -136,6 +137,7 @@ RSpec.describe SystemIndicatorsController, type: :controller do
     login_user
     let(:user_team) { @user.team }
     let(:some_team) { create(:team) }
+    let(:some_category) { create(:category, name: 'Buildings') }
     let!(:team_model) { create(:model, team: user_team) }
     let!(:some_model) { create(:model, team: some_team) }
     let(:team_indicator) { create(:indicator, model: team_model) }
@@ -163,7 +165,7 @@ RSpec.describe SystemIndicatorsController, type: :controller do
     describe 'POST create' do
       it 'prevents unauthorized access' do
         post :create, params: {
-          indicator: {category: ['Buildings']}
+          indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(root_url)
         expect(flash[:alert]).to match(/You are not authorized/)
@@ -182,7 +184,7 @@ RSpec.describe SystemIndicatorsController, type: :controller do
       it 'prevents unauthorized access' do
         put :update, params: {
           id: some_indicator.id,
-          indicator: {category: ['Buildings']}
+          indicator: {category_id: some_category.id}
         }
         expect(response).to redirect_to(root_url)
         expect(flash[:alert]).to match(/You are not authorized/)

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :category do
+    name 'Emissions'
+  end
+end
+

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :category do
-    name 'Emissions'
+    name { Faker::Pokemon.name }
   end
 end
 

--- a/spec/factories/indicators.rb
+++ b/spec/factories/indicators.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :indicator do
-    category 'Emissions'
-    subcategory 'Emissions by sector'
+    association :category, factory: :category, name: 'Emissions'
+    association :subcategory, factory: :category, name: 'Emissions by sector'
     name 'Industry'
     stackable_subcategory true
     unit 'Gt CO2e/yr'

--- a/spec/factories/indicators.rb
+++ b/spec/factories/indicators.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     association :category, factory: :category, name: 'Emissions'
     association :subcategory, factory: :category, name: 'Emissions by sector'
     name 'Industry'
-    stackable_subcategory true
     unit 'Gt CO2e/yr'
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -44,11 +44,6 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:form) {
         ActionView::Helpers::FormBuilder.new(:indicator, indicator, self, {})
       }
-      it 'returns a checkbox for release_date' do
-        expect(
-          helper.attribute_input(indicator, form, :stackable_subcategory)
-        ).to match('checkbox')
-      end
       it 'returns a select input for parent_id' do
         assign(:model, model)
         expect(

--- a/spec/helpers/indicators_helper_spec.rb
+++ b/spec/helpers/indicators_helper_spec.rb
@@ -4,20 +4,27 @@ RSpec.describe IndicatorsHelper, type: :helper do
   let(:team) { create(:team) }
   let(:model) { create(:model, team: team) }
   let(:other_model) { create(:model) }
-  let(:system_indicator) {
-    create(:indicator, category: 'Buildings')
+  let(:category) {
+    create(:category, name: 'Buildings')
   }
+  let(:another_category) {
+    create(:category, name: 'Transportation')
+  }
+  let(:system_indicator) {
+    create(:indicator, category: category, subcategory: nil)
+  }
+
   let!(:team_variation) {
     create(
-      :indicator, alias: '1|2|3', parent: system_indicator, model: model
+      :indicator, alias: '1|2|3', parent: system_indicator, model: model, category: nil, subcategory: nil
     )
   }
   let!(:team_indicator) {
-    create(:indicator, category: 'Transportation', model: model)
+    create(:indicator, category: another_category, subcategory: nil, model: model)
   }
   let!(:other_team_indicator) {
     create(
-      :indicator, category: 'Transportation', model: other_model
+      :indicator, category: another_category, subcategory: nil, model: other_model
     )
   }
 
@@ -49,7 +56,14 @@ RSpec.describe IndicatorsHelper, type: :helper do
     it 'returns categories without duplicates' do
       expect(
         helper.categories_for_select
-      ).to eq(options_for_select(%w(Buildings Transportation)))
+      ).to eq(
+        options_for_select(
+          [
+            [category.name, category.id],
+            [another_category.name, another_category.id]
+          ]
+        )
+      )
     end
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  context 'should be invalid' do
+    it 'when name not present' do
+      category = build(:category, name: nil)
+      expect(category).to have(1).errors_on(:name)
+    end
+
+    it 'when stackable without parent category' do
+      category = build(:category, parent_id: nil, stackable: true)
+      expect(category).to have(1).errors_on(:stackable)
+    end
+
+    it 'when parent category is a subcategory' do
+      grandparent_category = create(:category)
+      parent_category = create(:category, parent: grandparent_category)
+      category = build(:category, parent: parent_category)
+      expect(category).to have(1).errors_on(:parent)
+    end
+  end
+end

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -74,14 +74,22 @@ RSpec.describe Indicator, type: :model do
   context 'variations' do
     let(:model) { create(:model) }
     let(:system_indicator) {
+      category = create(
+        :category,
+        name: 'Buildings'
+      )
       create(
-        :indicator, parent: nil, model: nil, category: 'Buildings'
+        :indicator, parent: nil, model: nil, category: category
       )
     }
     let(:team_variation) {
+      category = create(
+        :category,
+        name: 'Transportation'
+      )
       create(
         :indicator,
-        parent: system_indicator, model: model, category: 'Transportation',
+        parent: system_indicator, model: model, category: category,
         unit: system_indicator.unit
       )
     }
@@ -102,7 +110,7 @@ RSpec.describe Indicator, type: :model do
     end
     describe :update_category do
       it 'updates category to match parent' do
-        expect(team_variation.category).to eq('Buildings')
+        expect(team_variation.category.name).to eq('Buildings')
       end
     end
   end

--- a/spec/models/metadata_attributes_info_spec.rb
+++ b/spec/models/metadata_attributes_info_spec.rb
@@ -46,20 +46,22 @@ RSpec.describe MetadataAttributes::Info, type: :model do
     end
   end
 
-  describe :checkbox? do
-    let(:checkbox_attribute_info) {
-      Indicator.attribute_info(:stackable_subcategory)
-    }
-    let(:not_checkbox_attribute_info) {
-      Indicator.attribute_info(:name)
-    }
-    it 'should be true when attribute is a checkbox' do
-      expect(checkbox_attribute_info.checkbox?).to be(true)
-    end
-    it 'should be false when attribute is not a picklist' do
-      expect(not_checkbox_attribute_info.checkbox?).to be(false)
-    end
-  end
+#  commented this test because there are no checkboxes rendered using MetadataAttributes
+#
+#  describe :checkbox? do
+#    let(:checkbox_attribute_info) {
+#      Indicator.attribute_info(:stackable_subcategory)
+#    }
+#    let(:not_checkbox_attribute_info) {
+#      Indicator.attribute_info(:name)
+#    }
+#    it 'should be true when attribute is a checkbox' do
+#      expect(checkbox_attribute_info.checkbox?).to be(true)
+#    end
+#    it 'should be false when attribute is not a picklist' do
+#      expect(not_checkbox_attribute_info.checkbox?).to be(false)
+#    end
+#  end
 
   describe :size do
     it 'expertise_detailed should have large size' do

--- a/spec/models/metadata_attributes_info_spec.rb
+++ b/spec/models/metadata_attributes_info_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe MetadataAttributes::Info, type: :model do
       Indicator.attribute_info(:stackable_subcategory)
     }
     let(:not_checkbox_attribute_info) {
-      Indicator.attribute_info(:category)
+      Indicator.attribute_info(:name)
     }
     it 'should be true when attribute is a checkbox' do
       expect(checkbox_attribute_info.checkbox?).to be(true)

--- a/spec/services/filter_indicators_spec.rb
+++ b/spec/services/filter_indicators_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe FilterIndicators do
     it 'filters by category' do
       expect(
         FilterIndicators.
-          new('category' => 'Energy').
+        new('category' => some_category.id.to_s).
           call(Indicator.all)
       ).to match_array([system_indicator])
     end

--- a/spec/services/filter_indicators_spec.rb
+++ b/spec/services/filter_indicators_spec.rb
@@ -1,10 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe FilterIndicators do
+  let(:some_category) {
+    create(:category, name: 'Energy')
+  }
+  let(:another_category) {
+    create(:category, name: 'Emissions')
+  }
+  let(:some_subcategory) {
+    create(:category, name: 'Energy use by fuel', parent: some_category)
+  }
+  let(:another_subcategory) {
+    create(:category, name: 'CO2 by sector', parent: another_category)
+  }
   let!(:system_indicator) do
     create(
       :indicator,
-      category: 'Energy', subcategory: 'Energy use by fuel', name: 'Biomass'
+      category: some_category, subcategory: some_subcategory, name: 'Biomass'
     )
   end
   let(:team) { create(:team, name: 'AAA') }
@@ -14,7 +26,7 @@ RSpec.describe FilterIndicators do
   let!(:team_indicator) do
     create(
       :indicator,
-      category: 'Emissions', subcategory: 'CO2 by sector', name: 'Industry',
+      category: another_category, subcategory: another_subcategory, name: 'Industry',
       model: model,
       alias: 'Hello|My|Custom2'
     )
@@ -22,7 +34,7 @@ RSpec.describe FilterIndicators do
   let!(:other_indicator) do
     create(
       :indicator,
-      category: 'Emissions', subcategory: 'CO2 by sector', name: 'Transport',
+      category: another_category, subcategory: another_subcategory, name: 'Transport',
       model: other_model,
       alias: 'Hello|My|Custom1'
     )
@@ -66,9 +78,9 @@ RSpec.describe FilterIndicators do
     it 'searches by slug' do
       expect(
         FilterIndicators.
-          new('search' => 'Emissions|CO2 by sector|Industry').
+          new('search' => 'Energy|Energy use by fuel|Biomass').
           call(Indicator.all)
-      ).to match_array([team_indicator])
+      ).to match_array([system_indicator])
     end
   end
 

--- a/spec/services/upload_indicators_spec.rb
+++ b/spec/services/upload_indicators_spec.rb
@@ -81,7 +81,12 @@ RSpec.describe UploadIndicators, upload: :s3 do
     }
     before(:each) do
       category = create(:category, name: 'Emissions')
-      subcategory = create(:category, name: 'CO2 by sector', parent: category)
+      subcategory = create(
+        :category,
+        name: 'CO2 by sector',
+        parent: category,
+        stackable: true
+      )
       create(
         :indicator,
         category: category,
@@ -190,12 +195,18 @@ RSpec.describe UploadIndicators, upload: :s3 do
     end
     it 'should have created one indicator with not stackable subcategory' do
       expect { subject }.to change {
-        Indicator.where(stackable_subcategory: false).count
+        Indicator.
+          includes(:subcategory).
+          references(:subcategory).
+          where(categories: {stackable: false}).count
       }.by(2)
     end
     it 'should have created one indicator with stackable subcategory' do
       expect { subject }.to change {
-        Indicator.where(stackable_subcategory: true).count
+        Indicator.
+          includes(:subcategory).
+          references(:subcategory).
+          where(categories: {stackable: true}).count
       }.by(2)
     end
   end

--- a/spec/services/upload_indicators_spec.rb
+++ b/spec/services/upload_indicators_spec.rb
@@ -80,10 +80,12 @@ RSpec.describe UploadIndicators, upload: :s3 do
       )
     }
     before(:each) do
+      category = create(:category, name: 'Emissions')
+      subcategory = create(:category, name: 'CO2 by sector', parent: category)
       create(
         :indicator,
-        category: 'Emissions',
-        subcategory: 'CO2 by sector',
+        category: category,
+        subcategory: subcategory,
         name: 'industry',
         unit: 'Mt CO2e/yr',
         model: nil,
@@ -258,10 +260,14 @@ RSpec.describe UploadIndicators, upload: :s3 do
     }
 
     before(:each) do
+      category = create(:category, name: 'Emissions')
+      subcategory1 = create(:category, name: 'CO2 by sector', parent: category)
+      subcategory2 = create(:category, name: 'CO2', parent: category)
+
       system_indicator = create(
         :indicator,
-        category: 'Emissions',
-        subcategory: 'CO2 by sector',
+        category: category,
+        subcategory: subcategory1,
         name: 'transport',
         unit: 'Mt CO2e/yr',
         model: nil,
@@ -269,8 +275,8 @@ RSpec.describe UploadIndicators, upload: :s3 do
       )
       create(
         :indicator,
-        category: 'Emissions',
-        subcategory: 'CO2',
+        category: category,
+        subcategory: subcategory2,
         name: 'Fossil Fuels and Industry|Energy Demand|Transport',
         unit: 'Mt CO2e/yr',
         model: model,

--- a/spec/services/upload_time_series_values_spec.rb
+++ b/spec/services/upload_time_series_values_spec.rb
@@ -8,11 +8,20 @@ RSpec.describe UploadTimeSeriesValues, upload: :s3 do
   let!(:scenario) {
     create(:scenario, name: 'Scenario 1', model: model)
   }
+  let(:category) {
+    create(:category, name: 'Emissions')
+  }
+  let(:subcategory) {
+    create(:category, name: 'GHG Emissions by gas', parent: category)
+  }
+  let(:another_subcategory) {
+    create(:category, name: 'GHG Emissions', parent: category)
+  }
   let!(:indicator) {
     create(
       :indicator,
-      category: 'Emissions',
-      subcategory: 'GHG Emissions by gas',
+      category: category,
+      subcategory: subcategory,
       name: 'CH4',
       stackable_subcategory: true,
       unit: 'Mt CO2e/yr',
@@ -358,8 +367,8 @@ RSpec.describe UploadTimeSeriesValues, upload: :s3 do
     let!(:team_indicator) {
       create(
         :indicator,
-        category: 'Emissions',
-        subcategory: 'GHG Emissions',
+        category: category,
+        subcategory: another_subcategory,
         name: 'direct',
         stackable_subcategory: true,
         unit: 'Mt CO2e/yr',
@@ -412,8 +421,8 @@ RSpec.describe UploadTimeSeriesValues, upload: :s3 do
     let!(:variation) {
       create(
         :indicator,
-        category: 'Emissions',
-        subcategory: 'GHG Emissions',
+        category: category,
+        subcategory: another_subcategory,
         name: 'direct',
         stackable_subcategory: true,
         unit: 'Mt CO2e/yr',

--- a/spec/services/upload_time_series_values_spec.rb
+++ b/spec/services/upload_time_series_values_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe UploadTimeSeriesValues, upload: :s3 do
     create(:category, name: 'Emissions')
   }
   let(:subcategory) {
-    create(:category, name: 'GHG Emissions by gas', parent: category)
+    create(:category, name: 'GHG Emissions by gas', parent: category, stackable: true)
   }
   let(:another_subcategory) {
-    create(:category, name: 'GHG Emissions', parent: category)
+    create(:category, name: 'GHG Emissions', parent: category, stackable: true)
   }
   let!(:indicator) {
     create(
@@ -23,7 +23,6 @@ RSpec.describe UploadTimeSeriesValues, upload: :s3 do
       category: category,
       subcategory: subcategory,
       name: 'CH4',
-      stackable_subcategory: true,
       unit: 'Mt CO2e/yr',
       unit_of_entry: 'Mt CH4/yr',
       conversion_factor: 25.0
@@ -370,7 +369,6 @@ RSpec.describe UploadTimeSeriesValues, upload: :s3 do
         category: category,
         subcategory: another_subcategory,
         name: 'direct',
-        stackable_subcategory: true,
         unit: 'Mt CO2e/yr',
         unit_of_entry: 'Mt CH4/yr',
         conversion_factor: 25.0,
@@ -424,7 +422,6 @@ RSpec.describe UploadTimeSeriesValues, upload: :s3 do
         category: category,
         subcategory: another_subcategory,
         name: 'direct',
-        stackable_subcategory: true,
         unit: 'Mt CO2e/yr',
         unit_of_entry: 'Mt CH4/yr',
         conversion_factor: 25.0,


### PR DESCRIPTION
This pull request does the following changes

- Moves the indicator categories/subcategories into its own Entity (Category)
- Updates the user interface to accomodate these changes
- Adds `/api/v1/categories` and a `category` query param filter to `/api/v1/indicators` that searches by category/subcategory id