### PR TITLE
Add /location/:iso/time_series_values endpoint

### DIFF
--- a/app/controllers/api/v1/location_time_series_values_controller.rb
+++ b/app/controllers/api/v1/location_time_series_values_controller.rb
@@ -1,0 +1,39 @@
+module Api
+  module V1
+    class LocationTimeSeriesValuesController < ApiController
+      before_action :set_location
+
+      def index
+        time_series_values = @location.time_series_values
+
+        if scenario_ids
+          time_series_values = time_series_values.
+            where(scenario_id: scenario_ids)
+        end
+
+        time_series_values = time_series_values.
+          group_by(&:indicator_id).
+          to_a
+
+        render json: time_series_values,
+               each_serializer: Api::V1::LocationTimeSeriesValuesSerializer
+      end
+
+      private
+
+      def set_location
+        @location = Location.
+          includes(:time_series_values).
+          find_by!(iso_code: params[:location_id])
+      end
+
+      def scenario_ids
+        if params[:scenario].blank?
+          nil
+        else
+          params[:scenario].split(',')
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/location_time_series_values_controller.rb
+++ b/app/controllers/api/v1/location_time_series_values_controller.rb
@@ -16,7 +16,8 @@ module Api
           to_a
 
         render json: time_series_values,
-               each_serializer: Api::V1::LocationTimeSeriesValuesSerializer
+               each_serializer: Api::V1::LocationTimeSeriesValuesSerializer,
+               include_scenario_id: params[:scenario].blank?
       end
 
       private
@@ -24,7 +25,7 @@ module Api
       def set_location
         @location = Location.
           includes(:time_series_values).
-          find_by!(iso_code: params[:location_id])
+          find_by!(id: params[:location_id])
       end
 
       def scenario_ids

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -7,4 +7,6 @@ class Location < ApplicationRecord
     uniqueness: true,
     unless: :region?
   )
+
+  has_many :time_series_values
 end

--- a/app/serializers/api/v1/location_time_series_values_serializer.rb
+++ b/app/serializers/api/v1/location_time_series_values_serializer.rb
@@ -10,11 +10,16 @@ module Api
 
       def values
         object.second.map do |tsv|
-          {
+          value = {
             year: tsv.year,
-            value: tsv.value,
-            scenario_id: tsv.scenario_id
+            value: tsv.value
           }
+
+          if instance_options[:include_scenario_id]
+            value[:scenario_id] = tsv.scenario_id
+          end
+
+          value
         end
       end
     end

--- a/app/serializers/api/v1/location_time_series_values_serializer.rb
+++ b/app/serializers/api/v1/location_time_series_values_serializer.rb
@@ -1,0 +1,22 @@
+module Api
+  module V1
+    class LocationTimeSeriesValuesSerializer < ActiveModel::Serializer
+      attribute :indicator_id
+      attribute :values
+
+      def indicator_id
+        object.first
+      end
+
+      def values
+        object.second.map do |tsv|
+          {
+            year: tsv.year,
+            value: tsv.value,
+            scenario_id: tsv.scenario_id
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,9 @@ Rails.application.routes.draw do
       resources :scenarios, only: [:index, :show]
       resources :indicators, only: [:index, :show]
       resources :time_series_values, only: [:index]
-      resources :locations, only: [:index]
+      resources :locations, only: [:index] do
+        resources :time_series_values, controller: :location_time_series_values, only: [:index]
+      end
       resources :categories, only: [:index]
     end
   end

--- a/spec/controllers/api/v1/location_time_series_values_controller_spec.rb
+++ b/spec/controllers/api/v1/location_time_series_values_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe Api::V1::LocationTimeSeriesValuesController, type: :controller do
+  context do
+    let!(:location) { create(:location) }
+    let!(:indicator) { create(:indicator) }
+    let!(:scenario) { create(:scenario) }
+    let!(:some_time_series_values) {
+      create_list(
+        :time_series_value,
+        10,
+        location: location,
+        indicator: indicator,
+        scenario: scenario
+      )
+    }
+
+    describe 'GET index' do
+      it 'returns a successful 200 response' do
+        get :index, params: {location_id: location.iso_code}
+        expect(response).to be_success
+      end
+
+      it 'lists all time series values' do
+        get :index, params: {location_id: location.iso_code}
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(1)
+        expect(parsed_body.first['values'].length).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/location_time_series_values_controller_spec.rb
+++ b/spec/controllers/api/v1/location_time_series_values_controller_spec.rb
@@ -17,12 +17,12 @@ describe Api::V1::LocationTimeSeriesValuesController, type: :controller do
 
     describe 'GET index' do
       it 'returns a successful 200 response' do
-        get :index, params: {location_id: location.iso_code}
+        get :index, params: {location_id: location.id}
         expect(response).to be_success
       end
 
       it 'lists all time series values' do
-        get :index, params: {location_id: location.iso_code}
+        get :index, params: {location_id: location.id}
         parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(1)
         expect(parsed_body.first['values'].length).to eq(10)


### PR DESCRIPTION
Url is `/api/v1/location/:iso/time_series_values`

Response sample: https://gist.githubusercontent.com/ticklemynausea/007d0767e1a10676f05fa1773edfe02c/raw/164bcb8f49e30dd9bf177e8b0137a2eae269662b/-

It supports an option `secenario`query parameter, which accepts a comma-separated list of scenario ids, which will be used to filter TimeSeriesValues.