### PR TITLE
Fix 20171123120735_add_unique_indexes_to_locations

### DIFF
--- a/db/migrate/20171123120735_add_unique_indexes_to_locations.rb
+++ b/db/migrate/20171123120735_add_unique_indexes_to_locations.rb
@@ -1,6 +1,10 @@
 class AddUniqueIndexesToLocations < ActiveRecord::Migration[5.1]
+  class Location < ApplicationRecord
+  end
+
   def change
+    Location.where(iso_code: '').update(iso_code: nil)
     add_index :locations, :name, unique: true
-    add_index :locations, :iso_code, unique: true
+    add_index :locations, :iso_code, unique: true, where: 'iso_code IS NOT NULL'
   end
 end

--- a/db/migrate/20171123120735_add_unique_indexes_to_locations.rb
+++ b/db/migrate/20171123120735_add_unique_indexes_to_locations.rb
@@ -5,6 +5,6 @@ class AddUniqueIndexesToLocations < ActiveRecord::Migration[5.1]
   def change
     Location.where(iso_code: '').update(iso_code: nil)
     add_index :locations, :name, unique: true
-    add_index :locations, :iso_code, unique: true, where: 'iso_code IS NOT NULL'
+    add_index :locations, :iso_code, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 20171123120735) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "iso_code"
-    t.index ["iso_code"], name: "index_locations_on_iso_code", unique: true, where: "(iso_code IS NOT NULL)"
+    t.index ["iso_code"], name: "index_locations_on_iso_code", unique: true
     t.index ["name"], name: "index_locations_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 20171123120735) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "iso_code"
-    t.index ["iso_code"], name: "index_locations_on_iso_code", unique: true
+    t.index ["iso_code"], name: "index_locations_on_iso_code", unique: true, where: "(iso_code IS NOT NULL)"
     t.index ["name"], name: "index_locations_on_name", unique: true
   end
 


### PR DESCRIPTION
This migration created an unique index over name and iso_code on the locations table,
but didn't contemplate the fact that there are several rows without iso_codes in the
production database (these rows refer to regions).

This fix does two things:
- converts empty iso strings to nulls
- changes the unique index on iso_code to be scoped to non-null values