### PR TITLE
Changed `/categories` serialization format

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -2,7 +2,11 @@ module Api
   module V1
     class CategoriesController < ApiController
       def index
-        categories = Category.order(:name).all
+        categories = Category.
+          where(parent_id: nil).
+          includes(:subcategories).
+          order(:name).
+          all
 
         render json: categories
       end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,9 +3,13 @@ class Category < ApplicationRecord
   validate :parent_categories_cannot_be_stackable,
            :cannot_have_subcategory_as_parent
 
-  belongs_to :parent, class_name: 'Category', foreign_key: 'parent_id',
+  belongs_to :parent,
+             class_name: 'Category',
+             foreign_key: 'parent_id',
              optional: true
-  has_many :subcategories, class_name: 'Category', foreign_key: 'parent_id'
+  has_many :subcategories, -> { order(:name) },
+           class_name: 'Category',
+           foreign_key: 'parent_id'
 
   accepts_nested_attributes_for :subcategories
 

--- a/app/serializers/api/v1/category_serializer.rb
+++ b/app/serializers/api/v1/category_serializer.rb
@@ -3,7 +3,8 @@ module Api
     class CategorySerializer < ActiveModel::Serializer
       attribute :id
       attribute :name
-      attribute :parent_id, if: -> { object.parent_id }
+
+      has_many :subcategories
     end
   end
 end


### PR DESCRIPTION
Now subcategories appear nested under their parents in favor of
using references to parents (exposing parent_id attribute)