### PR TITLE
Feature/data filtering on endpoints

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,6 +8,11 @@ The API endpoints are always prefixed by `/api/v1`.
 
 Lists all models
 
+### Query parameters
+
+* `time_series` - Filters locations by the presence of time_series_values
+associated with them.
+
 ## `GET /models/:id`
 
 Retrieves the model with the given id along with associated entities

--- a/API.md
+++ b/API.md
@@ -36,6 +36,14 @@ Retrieves the scenario with the given id along with associated entities
 
 Lists all indicators
 
+### Query parameters
+
+* `time_series` - Filters indicators by the presence of time_series_values associated with them.
+* `category` - Filters indicators by category. Accepts several categories ids, sperated by commas.
+* `subcategory` - Filters indicators by subcategory. Accepts several subcategories ids, sperated by commas.
+* `scenario` - Filters indicators by scenario. Accepts several scenarios ids, sperated by commas. Filtering happens via TimeSeriesValue. When this filter is used there's no need to pass `time_series`
+* `location` - Filters indicators by location. Accepts several locations ids, sperated by commas. Filtering happens via TimeSeriesValue. When this filter is used there's no need to pass `time_series`
+
 ## `GET /indicators/:id`
 
 Retrieves the indicator with the given id along with associated entities

--- a/API.md
+++ b/API.md
@@ -34,7 +34,12 @@ Retrieves the indicator with the given id along with associated entities
 
 ## `GET /locations`
 
-Lists all locations
+Lists all locations.
+
+### Query parameters
+* `time_series` - Filters locations by the presence of time_series_values
+associated with them.
+
 
 ## `GET /time_series_values`
 

--- a/API.md
+++ b/API.md
@@ -12,6 +12,7 @@ Lists all models
 
 * `time_series` - Filters locations by the presence of time_series_values
 associated with them.
+* `location` - Filter models by the location they have data for. Accepts several location ids, separated by commas.
 
 ## `GET /models/:id`
 
@@ -23,6 +24,8 @@ Lists all scenarios
 
 ### Query parameters
 
+* `time_series` - Filters locations by the presence of time_series_values
+associated with them.
 * `model` - Filters scenarios by the model id they belong to
 
 ## `GET /scenarios/:id`

--- a/app/controllers/api/v1/indicators_controller.rb
+++ b/app/controllers/api/v1/indicators_controller.rb
@@ -5,7 +5,7 @@ module Api
 
         indicators = if params[:time_series]
                        ind_ids = TimeSeriesValue.select(:indicator_id).distinct
-                       Indicator.where(id: ind_ids.map(&:indicator_id)
+                       Indicator.where(id: ind_ids.map(&:indicator_id))
                      else
                        Indicator.all
                      end

--- a/app/controllers/api/v1/indicators_controller.rb
+++ b/app/controllers/api/v1/indicators_controller.rb
@@ -10,7 +10,7 @@ module Api
                        Indicator.all
                      end
 
-        indicators = Indicator.
+        indicators = indicators.
           includes(:category, :subcategory, :model)
 
         if param_list(:category)

--- a/app/controllers/api/v1/indicators_controller.rb
+++ b/app/controllers/api/v1/indicators_controller.rb
@@ -45,9 +45,7 @@ module Api
           indicators = indicators.where(id: indicator_ids)
         end
 
-        indicators = indicators.
-          order(:name).
-          all
+        indicators = indicators.order(:name)
 
         render json: indicators
       end

--- a/app/controllers/api/v1/indicators_controller.rb
+++ b/app/controllers/api/v1/indicators_controller.rb
@@ -2,6 +2,14 @@ module Api
   module V1
     class IndicatorsController < ApiController
       def index
+
+        indicators = if params[:time_series]
+                       ind_ids = TimeSeriesValue.select(:indicator_id).distinct
+                       Indicator.where(id: ind_ids.map(&:indicator_id)
+                     else
+                       Indicator.all
+                     end
+
         indicators = Indicator.
           includes(:category, :subcategory, :model)
 

--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -2,7 +2,14 @@ module Api
   module V1
     class LocationsController < ApiController
       def index
-        locations = Location.order(:name).all
+        locations = if params[:time_series]
+                      loc_ids = TimeSeriesValue.select('distinct(location_id)')
+                      Location.where(id: loc_ids.map(&:location_id))
+                    else
+                      Location.all
+                    end
+        locations = locations.order(:name)
+
         render json: locations
       end
     end

--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -3,7 +3,7 @@ module Api
     class LocationsController < ApiController
       def index
         locations = if params[:time_series]
-                      loc_ids = TimeSeriesValue.select('distinct(location_id)')
+                      loc_ids = TimeSeriesValue.select(:location_id).distinct
                       Location.where(id: loc_ids.map(&:location_id))
                     else
                       Location.all

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -8,7 +8,8 @@ module Api
                    Model.all
                  end
 
-        models = models.filtered_by_locations(location_ids) if location_ids.present?
+        models = models.
+          filtered_by_locations(location_ids) if location_ids.present?
         models = models.with_scenarios_and_indicators
         models = models.order(:full_name)
 

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -2,17 +2,14 @@ module Api
   module V1
     class ModelsController < ApiController
       def index
-        if location_ids.blank?
-          models = Model.
-            includes(:scenarios, :indicators).
-            order(:full_name)
-        else
-          models = Model.
-            joins({indicators: {time_series_values: :location}}, :scenarios).
-            where(indicators:
-                      {time_series_values: {location_id: location_ids}}).
-            order(:full_name).distinct
-        end
+        models = if location_ids.present?
+                   Model.filtered_by_locations(location_ids)
+                 elsif params[:time_series]
+                   Model.have_time_series
+                 else
+                   Model.with_scenarios_and_indicators
+                 end
+        models = models.order(:full_name)
 
         render json: models
       end

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -2,13 +2,14 @@ module Api
   module V1
     class ModelsController < ApiController
       def index
-        models = if location_ids.present?
-                   Model.filtered_by_locations(location_ids)
-                 elsif params[:time_series]
+        models = if params[:time_series]
                    Model.have_time_series
                  else
-                   Model.with_scenarios_and_indicators
+                   Model.all
                  end
+
+        models = models.filtered_by_locations(location_ids) if location_ids.present?
+        models = models.with_scenarios_and_indicators
         models = models.order(:full_name)
 
         render json: models

--- a/app/controllers/api/v1/scenarios_controller.rb
+++ b/app/controllers/api/v1/scenarios_controller.rb
@@ -2,10 +2,17 @@ module Api
   module V1
     class ScenariosController < ApiController
       def index
-        scenarios = Scenario.
-          includes(model: :indicators).
-          order(:name)
+        scenarios = if params[:time_series]
+                      scenarios_ids = TimeSeriesValue.select(:scenario_id).
+                        distinct
+                      Scenario.where(id: scenarios_ids.map(&:scenario_id))
+                    else
+                      Scenario.all
+                    end
+
         scenarios = scenarios.where(model_id: params[:model]) if params[:model]
+
+        scenarios = scenarios.includes(model: :indicators).order(:name)
 
         render json: scenarios
       end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -28,7 +28,25 @@ class Model < ApplicationRecord
   validates :team, team_reassignment: true
   before_validation :ignore_blank_array_values
 
+  scope :with_scenarios_and_indicators, -> { includes(:scenarios, :indicators) }
+
   def scenarios?
     scenarios.any?
   end
+
+  class << self
+    def have_time_series
+      models_ids = TimeSeriesValue.joins(:scenario).
+        select(:model_id).distinct
+
+      where(id: models_ids.map(&:model_id))
+    end
+
+    def filtered_by_locations location_ids
+      joins({indicators: {time_series_values: :location}}, :scenarios).
+        where(indicators: {time_series_values: {location_id: location_ids}}).
+        distinct
+    end
+  end
+
 end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -42,11 +42,10 @@ class Model < ApplicationRecord
       where(id: models_ids.map(&:model_id))
     end
 
-    def filtered_by_locations location_ids
+    def filtered_by_locations(location_ids)
       joins({indicators: {time_series_values: :location}}, :scenarios).
         where(indicators: {time_series_values: {location_id: location_ids}}).
         distinct
     end
   end
-
 end

--- a/spec/controllers/api/v1/indicators_controller_spec.rb
+++ b/spec/controllers/api/v1/indicators_controller_spec.rb
@@ -22,7 +22,7 @@ describe Api::V1::IndicatorsController, type: :controller do
       end
 
       it 'list all indicators with time_series_values associated' do
-        get :index, params: { time_series: true }
+        get :index, params: {time_series: true}
 
         parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(1)

--- a/spec/controllers/api/v1/indicators_controller_spec.rb
+++ b/spec/controllers/api/v1/indicators_controller_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 describe Api::V1::IndicatorsController, type: :controller do
   context do
     let!(:some_indicator) { create(:indicator) }
+    let!(:indicator_with_time_series) {
+      ind = create(:indicator)
+      create(:time_series_value, indicator_id: ind.id)
+      ind
+    }
 
     describe 'GET index' do
       it 'returns a successful 200 response' do
@@ -12,6 +17,13 @@ describe Api::V1::IndicatorsController, type: :controller do
 
       it 'lists all indicators' do
         get :index
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(2)
+      end
+
+      it 'list all indicators with time_series_values associated' do
+        get :index, params: { time_series: true }
+
         parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(1)
       end

--- a/spec/controllers/api/v1/locations_controller_spec.rb
+++ b/spec/controllers/api/v1/locations_controller_spec.rb
@@ -22,7 +22,7 @@ describe Api::V1::LocationsController, type: :controller do
       end
 
       it 'list only locations with time_series_values data' do
-        get :index, params: { time_series: true }
+        get :index, params: {time_series: true}
         parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(1)
       end

--- a/spec/controllers/api/v1/locations_controller_spec.rb
+++ b/spec/controllers/api/v1/locations_controller_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 describe Api::V1::LocationsController, type: :controller do
   context do
     let!(:some_location) { create(:location) }
+    let!(:location_with_time_series) {
+      loc = create(:location)
+      create(:time_series_value, location_id: loc.id)
+      loc
+    }
 
     describe 'GET index' do
       it 'returns a successful 200 response' do
@@ -12,6 +17,12 @@ describe Api::V1::LocationsController, type: :controller do
 
       it 'lists all locations' do
         get :index
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(2)
+      end
+
+      it 'list only locations with time_series_values data' do
+        get :index, params: { time_series: true }
         parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(1)
       end

--- a/spec/controllers/api/v1/models_controller_spec.rb
+++ b/spec/controllers/api/v1/models_controller_spec.rb
@@ -2,7 +2,13 @@ require 'rails_helper'
 
 describe Api::V1::ModelsController, type: :controller do
   context do
-    let!(:some_models) { create_list(:model, 3) }
+    let!(:some_models) { create_list(:model, 2) }
+    let!(:model_with_time_series) {
+      my_model = create(:model)
+      scenario = create(:scenario, model_id: my_model.id)
+      create(:time_series_value, scenario_id: scenario.id)
+      my_model
+    }
 
     describe 'GET index' do
       it 'returns a successful 200 response' do
@@ -14,6 +20,12 @@ describe Api::V1::ModelsController, type: :controller do
         get :index
         parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(3)
+      end
+
+      it 'filters by models with time_series_values' do
+        get :index, params: { time_series: true }
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(1)
       end
     end
 

--- a/spec/controllers/api/v1/models_controller_spec.rb
+++ b/spec/controllers/api/v1/models_controller_spec.rb
@@ -23,7 +23,7 @@ describe Api::V1::ModelsController, type: :controller do
       end
 
       it 'filters by models with time_series_values' do
-        get :index, params: { time_series: true }
+        get :index, params: {time_series: true}
         parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(1)
       end

--- a/spec/controllers/api/v1/scenarios_controller_spec.rb
+++ b/spec/controllers/api/v1/scenarios_controller_spec.rb
@@ -5,7 +5,13 @@ describe Api::V1::ScenariosController, type: :controller do
     let!(:some_model) { create(:model) }
 
     let!(:some_scenarios) {
-      create_list(:scenario, 3, model: some_model)
+      create_list(:scenario, 2, model: some_model)
+    }
+
+    let!(:scenario_with_time_series) {
+      my_scenario = create(:scenario, model: some_model)
+      create(:time_series_value, scenario_id: my_scenario.id)
+      my_scenario
     }
 
     describe 'GET index' do
@@ -18,6 +24,12 @@ describe Api::V1::ScenariosController, type: :controller do
         get :index, params: {model_id: some_model.id}
         parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(3)
+      end
+
+      it 'lists all scenarios that have time_series_values associated' do
+        get :index, params: {time_series: true}
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(1)
       end
     end
 


### PR DESCRIPTION
This PR adds filtering as specified in this Pivotal Tracker story: https://www.pivotaltracker.com/story/show/153209865

It enables filtering by presence of time series values through the param `time_series` for the following endpoints:

- `GET /api/v1/models?time_series=true`
- `GET /api/v1/scenarios?time_series=true`
- `GET /api/v1/locations?time_series=true`
- `GET /api/v1/indicators?time_series=true`

Adds documentation into API.md