### PR TITLE
Filtering of Time Series Values by model was wrong.

### DIFF
--- a/app/controllers/api/v1/time_series_values_controller.rb
+++ b/app/controllers/api/v1/time_series_values_controller.rb
@@ -8,7 +8,10 @@ module Api
           order(:year)
         values = values.where(location_id: location_ids) if location_ids
         values = values.where(scenario_id: scenario_ids) if scenario_ids
-        values = values.where(indicators: {model_id: model_ids}) if model_ids
+        if model_ids
+          values = values.joins(:scenario).
+            where(scenarios: {model_id: model_ids})
+        end
         values = values.where(indicator_id: indicator_ids) if indicator_ids
 
         render json: values

--- a/spec/controllers/api/v1/time_series_values_controller_spec.rb
+++ b/spec/controllers/api/v1/time_series_values_controller_spec.rb
@@ -14,6 +14,18 @@ describe Api::V1::TimeSeriesValuesController, type: :controller do
         scenario: scenario
       )
     }
+    let!(:model_with_time_series) {
+      model = create(:model)
+      my_scenario = create(:scenario, model_id: model.id)
+      create_list(
+        :time_series_value,
+        5,
+        location: location,
+        indicator: indicator,
+        scenario: my_scenario
+      )
+      model
+    }
 
     describe 'GET index' do
       it 'returns a successful 200 response' do
@@ -24,7 +36,25 @@ describe Api::V1::TimeSeriesValuesController, type: :controller do
       it 'lists all time series values' do
         get :index
         parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(15)
+      end
+
+      it 'filters time_series_values by model' do
+        get :index, params: {model: model_with_time_series.id}
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(5)
+      end
+
+      it 'filters time_series_values by scenario' do
+        get :index, params: {scenario: scenario.id}
+        parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(10)
+      end
+
+      it 'filters time_series_values by indicator' do
+        get :index, params: {indicator: indicator.id}
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(15)
       end
     end
   end

--- a/spec/controllers/api/v1/time_series_values_controller_spec.rb
+++ b/spec/controllers/api/v1/time_series_values_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::TimeSeriesValuesController, type: :controller do
     let!(:some_time_series_values) {
       create_list(
         :time_series_value,
-        10,
+        3,
         location: location,
         indicator: indicator,
         scenario: scenario
@@ -19,7 +19,7 @@ describe Api::V1::TimeSeriesValuesController, type: :controller do
       my_scenario = create(:scenario, model_id: model.id)
       create_list(
         :time_series_value,
-        5,
+        1,
         location: location,
         indicator: indicator,
         scenario: my_scenario
@@ -36,25 +36,25 @@ describe Api::V1::TimeSeriesValuesController, type: :controller do
       it 'lists all time series values' do
         get :index
         parsed_body = JSON.parse(response.body)
-        expect(parsed_body.length).to eq(15)
+        expect(parsed_body.length).to eq(4)
       end
 
       it 'filters time_series_values by model' do
         get :index, params: {model: model_with_time_series.id}
         parsed_body = JSON.parse(response.body)
-        expect(parsed_body.length).to eq(5)
+        expect(parsed_body.length).to eq(1)
       end
 
       it 'filters time_series_values by scenario' do
         get :index, params: {scenario: scenario.id}
         parsed_body = JSON.parse(response.body)
-        expect(parsed_body.length).to eq(10)
+        expect(parsed_body.length).to eq(3)
       end
 
       it 'filters time_series_values by indicator' do
         get :index, params: {indicator: indicator.id}
         parsed_body = JSON.parse(response.body)
-        expect(parsed_body.length).to eq(15)
+        expect(parsed_body.length).to eq(4)
       end
     end
   end


### PR DESCRIPTION
This PR fixes the filtering of time series values by model. The correct way of filtering is to go through the scenarios and not the indicators, as that relation will cease to exist.

This PR also adds specs to test this and other bits of filtering.