### PR TITLE
Includes model inside the scenario object for the API requests

### DIFF
--- a/app/serializers/api/v1/scenario_serializer.rb
+++ b/app/serializers/api/v1/scenario_serializer.rb
@@ -36,6 +36,8 @@ module Api
       attribute :other_target_type
       attribute :other_target
       attribute :burden_sharing
+
+      belongs_to :model
     end
   end
 end


### PR DESCRIPTION
Álvaro, as discussed here is the inclusion of the model object inside the scenario request. I'm keeping model_id and model_name to avoid break other places of the app. But probably worth tidying up later.