### PR TITLE
Remove unneded and heavy models from responses

### DIFF
--- a/app/serializers/api/v1/model_serializer.rb
+++ b/app/serializers/api/v1/model_serializer.rb
@@ -22,11 +22,15 @@ module Api
       attribute :geographic_coverage
       attribute :url
 
-      has_many :scenarios
+      has_many :scenario_ids
       has_many :indicator_ids
 
       def indicator_ids
         object.indicators.pluck(:id)
+      end
+
+      def scenario_ids
+        object.scenarios.pluck(:id)
       end
     end
   end

--- a/app/serializers/api/v1/scenario_serializer.rb
+++ b/app/serializers/api/v1/scenario_serializer.rb
@@ -35,7 +35,6 @@ module Api
       attribute :other_target_type
       attribute :other_target
       attribute :burden_sharing
-      attribute :indicators
 
       belongs_to :model
       has_many :indicator_ids


### PR DESCRIPTION
The responses of scenarios and model were containing the full indicators and scenarios. They were 8mb each. Now we are only serving the ids. This will need some fix on the frontend but its needed.

The responses should be:

```
models: 
[{..., 
indicator_ids: [12,13,...],
scenario_ids: [12,13,...],
...
}]

scenarios: 
[{..., 
indicator_ids: [12,13,...],
...
}]
```