### PR TITLE
Update time_series_values when conversion factor changes

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -12,10 +12,19 @@ class Note < ApplicationRecord
   validates :conversion_factor, numericality: {other_than: 0, allow_nil: true}
 
   before_validation :ignore_blank_array_values
+  after_save :convert_time_series_values
 
   private
 
   def unit_of_entry_required?
     conversion_factor.present? && conversion_factor != 1
+  end
+
+  def convert_time_series_values
+    if saved_changes.keys.include?("conversion_factor") && self.conversion_factor
+      TimeSeriesValue.joins(scenario: [:model]).
+        where(models: { id: self.model_id}, indicator_id: self.indicator_id).
+        update_all("value = value * #{self.conversion_factor}")
+    end
   end
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe Note, type: :model do
   end
 
   context "after_save callback" do
-
     let(:note) {
       create(:note, conversion_factor: 1.0)
     }


### PR DESCRIPTION
If a user changes the conversion factor for an indicator against a model, update their time_series by multiplying it by the new conversion_factor.