### PR TITLE
Location filter using location ids rather than iso codes

### DIFF
--- a/app/services/api/v1/data/emission_pathways_filter.rb
+++ b/app/services/api/v1/data/emission_pathways_filter.rb
@@ -5,7 +5,7 @@ module Api
         attr_reader :years
 
         # @param params [Hash]
-        # @option params [Array<String>] :locations
+        # @option params [Array<Integer>] :location_ids
         # @option params [Array<Integer>] :model_ids
         # @option params [Array<Integer>] :scenario_ids
         # @option params [Array<Integer>] :category_ids
@@ -87,6 +87,7 @@ module Api
         def initialize_filters(params)
           # integer arrays
           [
+            :location_ids,
             :model_ids,
             :scenario_ids,
             :indicator_ids,
@@ -97,10 +98,6 @@ module Api
               value = params[param_name].map(&:to_i)
             end
             instance_variable_set(:"@#{param_name}", value)
-          end
-          if params[:locations]
-            @location_ids = Location.where(iso_code: params[:locations]).
-              pluck(:id)
           end
           @start_year = params[:start_year]
           @end_year = params[:end_year]

--- a/data_explorer.md
+++ b/data_explorer.md
@@ -3,7 +3,7 @@
 ## Emission Pathways
 
 ### Parameters
-- locations[] (ISO code 3)
+- location_ids[]
 - model_ids[]
 - scenario_ids[]
 - category_ids[]
@@ -18,7 +18,7 @@
 
 File format:
 
-ID | Iso code 3 | Location | Model | Scenario | Category | Subategory | Indicator| Unit | Definition | year 1 | year 2 | ...
+ID | Iso code 2 | Location | Model | Scenario | Category | Subategory | Indicator| Unit | Definition | year 1 | year 2 | ...
 
 ### JSON API endpoint
 

--- a/spec/controllers/api/v1/data/emission_pathways_controller_spec.rb
+++ b/spec/controllers/api/v1/data/emission_pathways_controller_spec.rb
@@ -21,7 +21,7 @@ describe Api::V1::Data::EmissionPathwaysController, type: :controller do
   describe 'GET index' do
     it 'renders emission pathways' do
       get :index, params: {
-        locations: [spain.iso_code],
+        location_ids: [spain.id],
         model_ids: [model.id],
         scenario_ids: [scenario.id],
         category_ids: [category.id],


### PR DESCRIPTION
Changes filtering by location in the data explorer API to use ids rather than iso codes, which will make it work for both regions and countries.