### PR TITLE
Replacing the nulls in the csv download with N/A

### DIFF
--- a/app/services/api/v1/data/column_helpers.rb
+++ b/app/services/api/v1/data/column_helpers.rb
@@ -5,7 +5,11 @@ module Api
         extend ActiveSupport::Concern
 
         def column_aliases
-          select_columns_map.map do |column_properties|
+          visible_columns = select_columns_map.select do |column_properties|
+            column_properties[:visible].nil? ||
+              column_properties[:visible] == true
+          end
+          visible_columns.map do |column_properties|
             column_properties[:alias]
           end
         end

--- a/app/services/api/v1/data/emission_pathways_csv_content.rb
+++ b/app/services/api/v1/data/emission_pathways_csv_content.rb
@@ -6,8 +6,7 @@ module Api
       class EmissionPathwaysCsvContent
         def initialize(filter)
           @grouped_query = filter.call
-          # FIXME: Should we just remove the columns we don't want by name?
-          @headers = filter.column_aliases[1...-1]
+          @headers = filter.column_aliases
           @years = filter.years
         end
 

--- a/app/services/api/v1/data/emission_pathways_csv_content.rb
+++ b/app/services/api/v1/data/emission_pathways_csv_content.rb
@@ -6,8 +6,8 @@ module Api
       class EmissionPathwaysCsvContent
         def initialize(filter)
           @grouped_query = filter.call
-          @headers = filter.column_aliases
-          @headers.shift
+          # FIXME: Should we just remove the columns we don't want by name?
+          @headers = filter.column_aliases[1...-1]
           @years = filter.years
         end
 
@@ -18,7 +18,7 @@ module Api
               ary = @headers.map { |h| record[h] }
               ary += @years.map do |y|
                 emission = record.emissions.find { |e| e['year'] == y }
-                emission && emission['value']
+                (emission && emission['value']) || 'N/A'
               end
               csv << ary
             end

--- a/app/services/api/v1/data/emission_pathways_filter.rb
+++ b/app/services/api/v1/data/emission_pathways_filter.rb
@@ -53,7 +53,8 @@ module Api
           [
             {
               column: 'indicators.id',
-              alias: 'id'
+              alias: 'id',
+              visible: false
             },
             {
               column: 'locations.iso_code',
@@ -97,7 +98,8 @@ module Api
               # rubocop:enable Metrics/LineLength
               alias: 'emissions',
               order: false,
-              group: false
+              group: false,
+              visible: false
             }
           ]
         end

--- a/spec/controllers/api/v1/data/emission_pathways_controller_spec.rb
+++ b/spec/controllers/api/v1/data/emission_pathways_controller_spec.rb
@@ -26,6 +26,10 @@ describe Api::V1::Data::EmissionPathwaysController, type: :controller do
   let(:indicator_2) {
     FactoryBot.create(:indicator, subcategory: subcategory_2, name: 'persica')
   }
+  let(:indicator_with_null) {
+    FactoryBot.
+      create(:indicator, subcategory: subcategory_2, name: 'with nulls')
+  }
   let!(:indicator_1_value) {
     FactoryBot.create(
       :time_series_value,
@@ -44,6 +48,16 @@ describe Api::V1::Data::EmissionPathwaysController, type: :controller do
       location: spain,
       year: 2030,
       value: 2.0
+    )
+  }
+  let!(:indicator_with_null_value) {
+    FactoryBot.create(
+      :time_series_value,
+      scenario: scenario,
+      indicator: indicator_with_null,
+      location: spain,
+      year: 2020,
+      value: 3.0
     )
   }
 
@@ -90,6 +104,13 @@ describe Api::V1::Data::EmissionPathwaysController, type: :controller do
       expect(response.content_type).to eq('text/csv')
       expect(response.headers['Content-Disposition']).
         to eq('attachment; filename=emission_pathways.csv')
+    end
+
+    it 'Replaces nulls with N/A' do
+      get :download
+      parsed_csv = CSV.parse(response.body)
+      puts parsed_csv
+      expect(parsed_csv.last.last).to eq('N/A')
     end
   end
 


### PR DESCRIPTION
- Replaced nulls with N/A in emissions pathways csv download. (Please check if this is the best way to fix this)
- Fixed a bug that was listing the emissions as a hash in the csv